### PR TITLE
Add Hiragino Fonts

### DIFF
--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -12,8 +12,8 @@
   set document(title: title)
 
   // Set the Fonts
-  let gothic = ("MS PGothic", "IPAexGothic", "Noto Sans CJK JP")
-  let mincho = ("MS PMincho", "IPAexMincho", "Noto Serif CJK JP")
+  let gothic = ("MS PGothic", "IPAexGothic", "Noto Sans CJK JP", "Hiragino Kaku Gothic Pro")
+  let mincho = ("MS PMincho", "IPAexMincho", "Noto Serif CJK JP", "Hiragino Mincho Pro")
 
   // Configure the page.
   set page(


### PR DESCRIPTION
Noto Sans CJK JP は少なくとも macOS Sonoma にはデフォルトでインストールされていないため、MS / IPA / Noto の全てが macOS では存在せず、いわゆる「中華フォント」と呼ばれるような見栄えの悪いフォントにフォールバックされた。そのため、ヒラギノの記述を追加。

なお、macOS Sonoma に含まれるフォントの内容は次のリンクに書かれている。
[macOS Sonoma に組み込まれているフォント - Apple](https://support.apple.com/ja-jp/108939)