### PR TITLE
FIX categories

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -8,7 +8,7 @@ authors = ["Shunsuke Kimura <https://github.com/kimushun1101>", "ささくらり
 license = "MIT-0"
 description = "Typst で日本語論文を書くときのテンプレート "
 keywords = ["japanese", "conference"]
-categories = ["thesis"]
+categories = ["paper"]
 
 [template]
 path = ""


### PR DESCRIPTION
@m-tsuru 
- #3 のチェック漏れですみません。学会論文は `conference proceedings` に当たるためcategoriesを変更します。
- こちらをご参照ください。https://github.com/typst/packages/blob/main/CATEGORIES.md#publication-categories