### PR TITLE
フォントが見つからないワーニングへの対応

### DIFF
--- a/docs/setting-fonts.md
+++ b/docs/setting-fonts.md
@@ -14,18 +14,18 @@ sudo apt-get install -y fonts-noto fonts-noto-cjk fonts-noto-cjk-extra
 BIZ UD フォントのインストールは
 ```
 # Install BIZUDGothic
-curl -L https://github.com/googlefonts/morisawa-biz-ud-gothic/releases/latest/download/morisawa-biz-ud-gothic-fonts.zip -o morisawa-biz-ud-gothic-fonts.zip
-unzip morisawa-biz-ud-gothic-fonts.zip
+curl -L https://github.com/googlefonts/morisawa-biz-ud-gothic/releases/latest/download/morisawa-biz-ud-font-gothics.zip -o morisawa-biz-ud-font-gothics.zip
+unzip morisawa-biz-ud-font-gothics.zip
 sudo mkdir /usr/local/share/fonts/BIZUDGothic
-sudo mv morisawa-biz-ud-gothic-fonts/fonts/ttf/*.ttf /usr/local/share/fonts/BIZUDGothic/
-rm -rf morisawa-biz-ud-gothic-fonts*
+sudo mv morisawa-biz-ud-font-gothics/fonts/ttf/*.ttf /usr/local/share/fonts/BIZUDGothic/
+rm -rf morisawa-biz-ud-font-gothics*
 
 # Install BIZUDMincho
-curl -L https://github.com/googlefonts/morisawa-biz-ud-mincho/releases/latest/download/morisawa-biz-ud-mincho-fonts.zip -o morisawa-biz-ud-mincho-fonts.zip
-unzip morisawa-biz-ud-mincho-fonts.zip
+curl -L https://github.com/googlefonts/morisawa-biz-ud-mincho/releases/latest/download/morisawa-biz-ud-font-minchos.zip -o morisawa-biz-ud-font-minchos.zip
+unzip morisawa-biz-ud-font-minchos.zip
 sudo mkdir /usr/local/share/fonts/BIZUDMincho
-sudo mv morisawa-biz-ud-mincho-fonts/fonts/ttf/*.ttf /usr/local/share/fonts/BIZUDMincho/
-rm -rf morisawa-biz-ud-mincho-fonts*
+sudo mv morisawa-biz-ud-font-minchos/fonts/ttf/*.ttf /usr/local/share/fonts/BIZUDMincho/
+rm -rf morisawa-biz-ud-font-minchos*
 
 # Update fonts cache
 fc-cache -vf

--- a/libs/mscs/lib.typ
+++ b/libs/mscs/lib.typ
@@ -1,11 +1,6 @@
 // Workaround for the lack of an `std` scope.
 #let std-bibliography = bibliography
 
-// Set the Fonts
-#let gothic = ("BIZ UDPGothic", "MS PGothic", "Hiragino Kaku Gothic Pro", "IPAexGothic", "Noto Sans CJK JP")
-#let mincho = ("BIZ UDPMincho", "MS PMincho", "Hiragino Mincho Pro", "IPAexMincho", "Noto Serif CJK JP")
-#let english = ("Times New Roman", "New Computer Modern")
-
 #let mscs(
   title: [タイトル],
   authors: [著者],
@@ -14,6 +9,9 @@
   abstract: none,
   keywords: (),
   bibliography: none,
+  gothic-font: "BIZ UDPGothic",
+  mincho-font: "BIZ UDPMincho",
+  latin-font: "New Computer Modern",
   body
 ) = {
   // Set document metadata.
@@ -24,7 +22,7 @@
     paper: "a4",
     margin: (top: 20mm, bottom: 27mm, x: 20mm)
   )
-  set text(size: 10pt, font: mincho)
+  set text(size: 10pt, font: mincho-font)
   // show regex("[0-9a-zA-Z]"): set text(font: "New Computer Modern Math")
   set par(leading: 0.55em, first-line-indent: 1em, justify: true, spacing: 0.55em)
 
@@ -65,7 +63,7 @@
       // We don't want to number of the acknowledgment section.
       #set par(first-line-indent: 0pt)
       #let is-ack = it.body in ([謝辞], [Acknowledgment], [Acknowledgement])
-      #set text(if is-ack { 11pt } else { 11pt }, font: gothic)
+      #set text(if is-ack { 11pt } else { 11pt }, font: gothic-font)
       #v(20pt, weak: true)
       #if it.numbering != none and not is-ack {
         numbering("1.", ..levels)
@@ -94,19 +92,19 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [: ])
 
   // Display the paper's title.
-  align(center, text(16pt, title, weight: "bold", font: gothic))
+  align(center, text(16pt, title, weight: "bold", font: gothic-font))
   v(18pt, weak: true)
 
   // Display the authors list.
-  align(center, text(12pt, authors, font: mincho))
+  align(center, text(12pt, authors, font: mincho-font))
   v(1.5em, weak: true)
 
   // Display the paper's title in English.
-  align(center, text(12pt, etitle, weight: "bold", font: english))
+  align(center, text(12pt, etitle, weight: "bold", font: latin-font))
   v(1.5em, weak: true)
 
   // Display the authors list in English.
-  align(center, text(12pt, eauthors, font: english))
+  align(center, text(12pt, eauthors, font: latin-font))
   v(1.5em, weak: true)
 
   // Display abstract and index terms.
@@ -115,7 +113,7 @@
       columns: (0.7cm, 1fr, 0.7cm),
       [],
       [
-        #set text(10pt, font: english)
+        #set text(10pt, font: latin-font)
         #set par(first-line-indent: 0pt)
         *Abstract--* #h(0.5em) #abstract
         #v(1em)
@@ -135,7 +133,7 @@
   // Display bibliography.
   if bibliography != none {
     show std-bibliography: set text(9pt)
-    show regex("[0-9a-zA-Z]"): set text(font: english)
+    show regex("[0-9a-zA-Z]"): set text(font: latin-font)
     set std-bibliography(title:  align(center, text(11pt)[参　考　文　献]), style: "sice.csl")
     bibliography
   }

--- a/libs/mscs/lib.typ
+++ b/libs/mscs/lib.typ
@@ -2,8 +2,8 @@
 #let std-bibliography = bibliography
 
 #let mscs(
-  title: [タイトル],
-  authors: [著者],
+  title-ja: [タイトル],
+  authors-ja: [著者],
   title-en: "", 
   authors-en: "",
   abstract: none,
@@ -15,7 +15,7 @@
   body
 ) = {
   // Set document metadata.
-  set document(title: title)
+  set document(title: title-ja)
 
   // Configure the page.
   set page(
@@ -92,11 +92,11 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [: ])
 
   // Display the paper's title.
-  align(center, text(16pt, title, weight: "bold", font: font-gothic))
+  align(center, text(16pt, title-ja, weight: "bold", font: font-gothic))
   v(18pt, weak: true)
 
   // Display the authors list.
-  align(center, text(12pt, authors, font: font-mincho))
+  align(center, text(12pt, authors-ja, font: font-mincho))
   v(1.5em, weak: true)
 
   // Display the paper's title in English.

--- a/libs/mscs/lib.typ
+++ b/libs/mscs/lib.typ
@@ -4,14 +4,14 @@
 #let mscs(
   title: [タイトル],
   authors: [著者],
-  etitle: "", 
-  eauthors: "",
+  title-en: "", 
+  authors-en: "",
   abstract: none,
   keywords: (),
   bibliography: none,
-  gothic-font: "BIZ UDPGothic",
-  mincho-font: "BIZ UDPMincho",
-  latin-font: "New Computer Modern",
+  font-gothic: "BIZ UDPGothic",
+  font-mincho: "BIZ UDPMincho",
+  font-latin: "New Computer Modern",
   body
 ) = {
   // Set document metadata.
@@ -22,7 +22,7 @@
     paper: "a4",
     margin: (top: 20mm, bottom: 27mm, x: 20mm)
   )
-  set text(size: 10pt, font: mincho-font)
+  set text(size: 10pt, font: font-mincho)
   // show regex("[0-9a-zA-Z]"): set text(font: "New Computer Modern Math")
   set par(leading: 0.55em, first-line-indent: 1em, justify: true, spacing: 0.55em)
 
@@ -63,7 +63,7 @@
       // We don't want to number of the acknowledgment section.
       #set par(first-line-indent: 0pt)
       #let is-ack = it.body in ([謝辞], [Acknowledgment], [Acknowledgement])
-      #set text(if is-ack { 11pt } else { 11pt }, font: gothic-font)
+      #set text(if is-ack { 11pt } else { 11pt }, font: font-gothic)
       #v(20pt, weak: true)
       #if it.numbering != none and not is-ack {
         numbering("1.", ..levels)
@@ -92,19 +92,19 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [: ])
 
   // Display the paper's title.
-  align(center, text(16pt, title, weight: "bold", font: gothic-font))
+  align(center, text(16pt, title, weight: "bold", font: font-gothic))
   v(18pt, weak: true)
 
   // Display the authors list.
-  align(center, text(12pt, authors, font: mincho-font))
+  align(center, text(12pt, authors, font: font-mincho))
   v(1.5em, weak: true)
 
   // Display the paper's title in English.
-  align(center, text(12pt, etitle, weight: "bold", font: latin-font))
+  align(center, text(12pt, title-en, weight: "bold", font: font-latin))
   v(1.5em, weak: true)
 
   // Display the authors list in English.
-  align(center, text(12pt, eauthors, font: latin-font))
+  align(center, text(12pt, authors-en, font: font-latin))
   v(1.5em, weak: true)
 
   // Display abstract and index terms.
@@ -113,7 +113,7 @@
       columns: (0.7cm, 1fr, 0.7cm),
       [],
       [
-        #set text(10pt, font: latin-font)
+        #set text(10pt, font: font-latin)
         #set par(first-line-indent: 0pt)
         *Abstract--* #h(0.5em) #abstract
         #v(1em)
@@ -133,7 +133,7 @@
   // Display bibliography.
   if bibliography != none {
     show std-bibliography: set text(9pt)
-    show regex("[0-9a-zA-Z]"): set text(font: latin-font)
+    show regex("[0-9a-zA-Z]"): set text(font: font-latin)
     set std-bibliography(title:  align(center, text(11pt)[参　考　文　献]), style: "sice.csl")
     bibliography
   }

--- a/libs/rengo/lib.typ
+++ b/libs/rengo/lib.typ
@@ -1,11 +1,6 @@
 // Workaround for the lack of an `std` scope.
 #let std-bibliography = bibliography
 
-// Set the Fonts
-#let gothic = ("BIZ UDPGothic", "MS PGothic", "Hiragino Kaku Gothic Pro", "IPAexGothic", "Noto Sans CJK JP")
-#let mincho = ("BIZ UDPMincho", "MS PMincho", "Hiragino Mincho Pro", "IPAexMincho", "Noto Serif CJK JP")
-#let english = ("Times New Roman", "New Computer Modern")
-
 #let rengo(
   title: [タイトル],
   authors: [著者],
@@ -14,6 +9,9 @@
   abstract: none,
   keywords: (),
   bibliography: none,
+  gothic-font: "BIZ UDPGothic",
+  mincho-font: "BIZ UDPMincho",
+  latin-font: "New Computer Modern",
   body
 ) = {
   // Set document metadata.
@@ -24,7 +22,7 @@
     paper: "a4",
     margin: (top: 20mm, bottom: 27mm, x: 20mm)
   )
-  set text(size: 10pt, font: mincho)
+  set text(size: 10pt, font: mincho-font)
   // show regex("[0-9a-zA-Z]"): set text(font: "New Computer Modern Math")
   set par(leading: 0.55em, first-line-indent: 1em, justify: true, spacing: 0.55em)
 
@@ -65,7 +63,7 @@
       // We don't want to number of the acknowledgment section.
       #set par(first-line-indent: 0pt)
       #let is-ack = it.body in ([謝辞], [Acknowledgment], [Acknowledgement])
-      #set text(if is-ack { 11pt } else { 11pt }, font: gothic)
+      #set text(if is-ack { 11pt } else { 11pt }, font: gothic-font)
       #v(20pt, weak: true)
       #if it.numbering != none and not is-ack {
         numbering("1.", ..levels)
@@ -94,19 +92,19 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [: ])
 
   // Display the paper's title.
-  align(center, text(16pt, title, weight: "bold", font: gothic))
+  align(center, text(16pt, title, weight: "bold", font: gothic-font))
   v(16pt, weak: true)
 
   // Display the authors list.
-  align(center, text(12pt, authors, font: mincho))
+  align(center, text(12pt, authors, font: mincho-font))
   v(1.5em, weak: true)
 
   // Display the paper's title in English.
-  align(center, text(12pt, etitle, weight: "bold", font: english))
+  align(center, text(12pt, etitle, weight: "bold", font: latin-font))
   v(1.5em, weak: true)
 
   // Display the authors list in English.
-  align(center, text(12pt, eauthors, font: english))
+  align(center, text(12pt, eauthors, font: latin-font))
   v(1.5em, weak: true)
 
   // Display abstract and index terms.
@@ -115,7 +113,7 @@
       columns: (0.7cm, 1fr, 0.7cm),
       [],
       [
-        #set text(10pt, font: english)
+        #set text(10pt, font: latin-font)
         #set par(first-line-indent: 0pt)
         *Abstract:* #h(0.5em) #abstract
         #v(1em)
@@ -135,7 +133,7 @@
   // Display bibliography.
   if bibliography != none {
     show std-bibliography: set text(9pt)
-    show regex("[0-9a-zA-Z]"): set text(font: english)
+    show regex("[0-9a-zA-Z]"): set text(font: latin-font)
     set std-bibliography(title: text(12pt)[参考文献], style: "rengo.csl")
     bibliography
   }

--- a/libs/rengo/lib.typ
+++ b/libs/rengo/lib.typ
@@ -4,14 +4,14 @@
 #let rengo(
   title: [タイトル],
   authors: [著者],
-  etitle: "", 
-  eauthors: "",
+  title-en: "", 
+  authors-en: "",
   abstract: none,
   keywords: (),
   bibliography: none,
-  gothic-font: "BIZ UDPGothic",
-  mincho-font: "BIZ UDPMincho",
-  latin-font: "New Computer Modern",
+  font-gothic: "BIZ UDPGothic",
+  font-mincho: "BIZ UDPMincho",
+  font-latin: "New Computer Modern",
   body
 ) = {
   // Set document metadata.
@@ -22,7 +22,7 @@
     paper: "a4",
     margin: (top: 20mm, bottom: 27mm, x: 20mm)
   )
-  set text(size: 10pt, font: mincho-font)
+  set text(size: 10pt, font: font-mincho)
   // show regex("[0-9a-zA-Z]"): set text(font: "New Computer Modern Math")
   set par(leading: 0.55em, first-line-indent: 1em, justify: true, spacing: 0.55em)
 
@@ -63,7 +63,7 @@
       // We don't want to number of the acknowledgment section.
       #set par(first-line-indent: 0pt)
       #let is-ack = it.body in ([謝辞], [Acknowledgment], [Acknowledgement])
-      #set text(if is-ack { 11pt } else { 11pt }, font: gothic-font)
+      #set text(if is-ack { 11pt } else { 11pt }, font: font-gothic)
       #v(20pt, weak: true)
       #if it.numbering != none and not is-ack {
         numbering("1.", ..levels)
@@ -92,19 +92,19 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [: ])
 
   // Display the paper's title.
-  align(center, text(16pt, title, weight: "bold", font: gothic-font))
+  align(center, text(16pt, title, weight: "bold", font: font-gothic))
   v(16pt, weak: true)
 
   // Display the authors list.
-  align(center, text(12pt, authors, font: mincho-font))
+  align(center, text(12pt, authors, font: font-mincho))
   v(1.5em, weak: true)
 
   // Display the paper's title in English.
-  align(center, text(12pt, etitle, weight: "bold", font: latin-font))
+  align(center, text(12pt, title-en, weight: "bold", font: font-latin))
   v(1.5em, weak: true)
 
   // Display the authors list in English.
-  align(center, text(12pt, eauthors, font: latin-font))
+  align(center, text(12pt, authors-en, font: font-latin))
   v(1.5em, weak: true)
 
   // Display abstract and index terms.
@@ -113,7 +113,7 @@
       columns: (0.7cm, 1fr, 0.7cm),
       [],
       [
-        #set text(10pt, font: latin-font)
+        #set text(10pt, font: font-latin)
         #set par(first-line-indent: 0pt)
         *Abstract:* #h(0.5em) #abstract
         #v(1em)
@@ -133,7 +133,7 @@
   // Display bibliography.
   if bibliography != none {
     show std-bibliography: set text(9pt)
-    show regex("[0-9a-zA-Z]"): set text(font: latin-font)
+    show regex("[0-9a-zA-Z]"): set text(font: font-latin)
     set std-bibliography(title: text(12pt)[参考文献], style: "rengo.csl")
     bibliography
   }

--- a/libs/rengo/lib.typ
+++ b/libs/rengo/lib.typ
@@ -2,8 +2,8 @@
 #let std-bibliography = bibliography
 
 #let rengo(
-  title: [タイトル],
-  authors: [著者],
+  title-ja: [タイトル],
+  authors-ja: [著者],
   title-en: "", 
   authors-en: "",
   abstract: none,
@@ -15,7 +15,7 @@
   body
 ) = {
   // Set document metadata.
-  set document(title: title)
+  set document(title: title-ja)
 
   // Configure the page.
   set page(
@@ -92,11 +92,11 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [: ])
 
   // Display the paper's title.
-  align(center, text(16pt, title, weight: "bold", font: font-gothic))
+  align(center, text(16pt, title-ja, weight: "bold", font: font-gothic))
   v(16pt, weak: true)
 
   // Display the authors list.
-  align(center, text(12pt, authors, font: font-mincho))
+  align(center, text(12pt, authors-ja, font: font-mincho))
   v(1.5em, weak: true)
 
   // Display the paper's title in English.

--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -1,16 +1,14 @@
 // Workaround for the lack of an `std` scope.
 #let std-bibliography = bibliography
 
-// Set the Fonts
-#let gothic = ("BIZ UDPGothic", "MS PGothic", "Hiragino Kaku Gothic Pro", "IPAexGothic", "Noto Sans CJK JP")
-#let mincho = ("BIZ UDPMincho", "MS PMincho", "Hiragino Mincho Pro", "IPAexMincho", "Noto Serif CJK JP")
-#let english = ("Times New Roman", "New Computer Modern")
-
 #let rsj-conf(
   title: [タイトル],
   authors: [著者],
   abstract: none,
   bibliography: none,
+  gothic-font: "BIZ UDPGothic",
+  mincho-font: "BIZ UDPMincho",
+  latin-font: "New Computer Modern",
   body
 ) = {
   // Set document metadata.
@@ -22,8 +20,7 @@
     margin: (top: 20mm, bottom: 27mm, x: 20mm)
   )
 
-  set text(size: 10pt, font: mincho)
-  // show regex("[0-9a-zA-Z]"): set text(font: english)
+  set text(size: 10pt, font: mincho-font)
   set par(leading: 0.55em, first-line-indent: 1em, justify: true, spacing: 0.55em)
 
   // Configure equation numbering and spacing.
@@ -63,7 +60,7 @@
       // We don't want to number of the acknowledgment section.
       #set par(first-line-indent: 0pt)
       #let is-ack = it.body in ([謝辞], [Acknowledgment], [Acknowledgement])
-      #set text(if is-ack { 11pt } else { 11pt }, font: gothic)
+      #set text(if is-ack { 11pt } else { 11pt }, font: gothic-font)
       #v(20pt, weak: true)
       #if it.numbering != none and not is-ack {
         numbering("1.", ..levels)
@@ -91,11 +88,11 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [ ])
 
   // Display the paper's title.
-  align(center, text(18pt, title, weight: "bold", font: gothic))
+  align(center, text(18pt, title, weight: "bold", font: gothic-font))
   v(2em, weak: true)
 
   // Display the authors list.
-  align(center, text(12pt, authors, font: mincho))
+  align(center, text(12pt, authors, font: mincho-font))
   v(2em, weak: true)
 
   // Display abstract and index terms.
@@ -104,7 +101,7 @@
       columns: (0.7cm, 1fr, 0.7cm),
       [],
       [
-        #set text(10pt, font: english)
+        #set text(10pt, font: latin-font)
         #h(1em) #abstract
       ],
       []
@@ -121,7 +118,7 @@
   // Display bibliography.
   if bibliography != none {
     show std-bibliography: set text(9pt)
-    show regex("[0-9a-zA-Z]"): set text(font: english)
+    show regex("[0-9a-zA-Z]"): set text(font: latin-font)
     set std-bibliography(title:  align(center, text(11pt)[参　考　文　献]), style: "rsj-conf.csl")
     bibliography
   }

--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -2,9 +2,9 @@
 #let std-bibliography = bibliography
 
 #let rsj-conf(
-  title: [タイトル],
+  title-ja: [タイトル],
   title-en: [],
-  authors: [著者],
+  authors-ja: [著者],
   authors-en: [],
   abstract: none,
   keywords: (),
@@ -15,7 +15,7 @@
   body
 ) = {
   // Set document metadata.
-  set document(title: title)
+  set document(title: title-ja)
 
   // Configure the page.
   set page(
@@ -91,11 +91,11 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [ ])
 
   // Display the paper's title.
-  align(center, text(18pt, title, weight: "bold", font: font-gothic))
+  align(center, text(18pt, title-ja, weight: "bold", font: font-gothic))
   v(2em, weak: true)
 
   // Display the authors list.
-  align(center, text(12pt, authors, font: font-mincho))
+  align(center, text(12pt, authors-ja, font: font-mincho))
   v(2em, weak: true)
 
   // Display abstract and index terms.

--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -3,12 +3,15 @@
 
 #let rsj-conf(
   title: [タイトル],
+  title-en: [],
   authors: [著者],
+  authors-en: [],
   abstract: none,
+  keywords: (),
   bibliography: none,
-  gothic-font: "BIZ UDPGothic",
-  mincho-font: "BIZ UDPMincho",
-  latin-font: "New Computer Modern",
+  font-gothic: "BIZ UDPGothic",
+  font-mincho: "BIZ UDPMincho",
+  font-latin: "New Computer Modern",
   body
 ) = {
   // Set document metadata.
@@ -20,7 +23,7 @@
     margin: (top: 20mm, bottom: 27mm, x: 20mm)
   )
 
-  set text(size: 10pt, font: mincho-font)
+  set text(size: 10pt, font: font-mincho)
   set par(leading: 0.55em, first-line-indent: 1em, justify: true, spacing: 0.55em)
 
   // Configure equation numbering and spacing.
@@ -60,7 +63,7 @@
       // We don't want to number of the acknowledgment section.
       #set par(first-line-indent: 0pt)
       #let is-ack = it.body in ([謝辞], [Acknowledgment], [Acknowledgement])
-      #set text(if is-ack { 11pt } else { 11pt }, font: gothic-font)
+      #set text(if is-ack { 11pt } else { 11pt }, font: font-gothic)
       #v(20pt, weak: true)
       #if it.numbering != none and not is-ack {
         numbering("1.", ..levels)
@@ -88,11 +91,11 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [ ])
 
   // Display the paper's title.
-  align(center, text(18pt, title, weight: "bold", font: gothic-font))
+  align(center, text(18pt, title, weight: "bold", font: font-gothic))
   v(2em, weak: true)
 
   // Display the authors list.
-  align(center, text(12pt, authors, font: mincho-font))
+  align(center, text(12pt, authors, font: font-mincho))
   v(2em, weak: true)
 
   // Display abstract and index terms.
@@ -101,7 +104,7 @@
       columns: (0.7cm, 1fr, 0.7cm),
       [],
       [
-        #set text(10pt, font: latin-font)
+        #set text(10pt, font: font-latin)
         #h(1em) #abstract
       ],
       []
@@ -118,7 +121,7 @@
   // Display bibliography.
   if bibliography != none {
     show std-bibliography: set text(9pt)
-    show regex("[0-9a-zA-Z]"): set text(font: latin-font)
+    show regex("[0-9a-zA-Z]"): set text(font: font-latin)
     set std-bibliography(title:  align(center, text(11pt)[参　考　文　献]), style: "rsj-conf.csl")
     bibliography
   }

--- a/main.typ
+++ b/main.typ
@@ -17,47 +17,25 @@
 // #let english = ("Times New Roman")
 
 // example 3: Linux or Typst app
-#let gothic = ("Noto Sans CJK JP", "IPAexGothic")
+#let gothic = ("Noto Sans CJK JP")
 #let mincho = ("Noto Serif CJK JP")
 #let latin = ("New Computer Modern")
 
-// #import "libs/rsj-conf/lib.typ": rsj-conf
-// #show: rsj-conf.with(
-//   title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
-//   authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
-//   abstract: [#lorem(80)],
-//   bibliography: bibliography("refs.yml", full: false),
-//   gothic-font: gothic,
-//   mincho-font: mincho,
-//   latin-font: latin
-// )
+#import "libs/rsj-conf/lib.typ": rsj-conf as temp
+// #import "libs/rengo/lib.typ": rengo as temp
+// #import "libs/mscs/lib.typ": mscs as temp
 
-// #import "libs/rengo/lib.typ": rengo
-// #show: rengo.with(
-//   title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
-//   authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
-//   etitle: [How to Write a Conference Paper in Japanese],
-//   eauthors: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
-//   abstract: [#lorem(80)],
-//   keywords: ([Typst], [conference paper writing], [manuscript format]),
-//   bibliography: bibliography("refs.yml", full: false),
-//   gothic-font: gothic,
-//   mincho-font: mincho,
-//   latin-font: latin
-// )
-
-#import "libs/mscs/lib.typ": mscs
-#show: mscs.with(
+#show: temp.with(
   title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
+  title-en: [How to Write a Conference Paper in Japanese],
   authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
-  etitle: [How to Write a Conference Paper in Japanese],
-  eauthors: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
+  authors-en: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),
   bibliography: bibliography("refs.yml", full: false),
-  gothic-font: gothic,
-  mincho-font: mincho,
-  latin-font: latin
+  font-gothic: gothic,
+  font-mincho: mincho,
+  font-latin: latin
 )
 
 // 定理環境
@@ -254,14 +232,14 @@ Typst Universe から自動でインストールされたものを使ってお�
   #show: rengo.with(
     title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
     authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
-    etitle: [How to write a conference paper in Japanese],
-    eauthors: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
+    title-en: [How to write a conference paper in Japanese],
+    authors-en: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
     abstract: [#lorem(80)],
     keywords: ([Typst], [conference paper writing], [manuscript format]),
     bibliography: bibliography("refs.yml", full: false)
   )
 ```
-このフォーマットですと，`etitle`, `eauthors`, `keywords` が追加されており，それぞれ英語タイトル，英語著者名，キーワードを意味しています．
+このフォーマットですと，`title-en`, `authors-en`, `keywords` が追加されており，それぞれ英語タイトル，英語著者名，キーワードを意味しています．
 `keywords` は`()` のリスト形式で指定されていることに注意してください．
 
 `#import` でテンプレートの関数を持ってくるところと，その関数を使用するところ以外の本文部分のコードはテンプレートの変更に応じて変更する必要はありません．

--- a/main.typ
+++ b/main.typ
@@ -21,27 +21,30 @@
 #let mincho = ("Noto Serif CJK JP")
 #let latin = ("New Computer Modern")
 
-#import "libs/rsj-conf/lib.typ": rsj-conf
-#show: rsj-conf.with(
+// #import "libs/rsj-conf/lib.typ": rsj-conf
+// #show: rsj-conf.with(
+//   title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
+//   authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
+//   abstract: [#lorem(80)],
+//   bibliography: bibliography("refs.yml", full: false),
+//   gothic-font: gothic,
+//   mincho-font: mincho,
+//   latin-font: latin
+// )
+
+#import "libs/rengo/lib.typ": rengo
+#show: rengo.with(
   title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
   authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
+  etitle: [How to Write a Conference Paper in Japanese],
+  eauthors: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
   abstract: [#lorem(80)],
+  keywords: ([Typst], [conference paper writing], [manuscript format]),
   bibliography: bibliography("refs.yml", full: false),
   gothic-font: gothic,
   mincho-font: mincho,
   latin-font: latin
 )
-
-// #import "libs/rengo/lib.typ": rengo, gothic
-// #show: rengo.with(
-//   title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
-//   authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
-//   etitle: [How to Write a Conference Paper in Japanese],
-//   eauthors: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
-//   abstract: [#lorem(80)],
-//   keywords: ([Typst], [conference paper writing], [manuscript format]),
-//   bibliography: bibliography("refs.yml", full: false)
-// )
 
 // #import "libs/mscs/lib.typ": mscs, gothic
 // #show: mscs.with(

--- a/main.typ
+++ b/main.typ
@@ -26,9 +26,9 @@
 // #import "libs/mscs/lib.typ": mscs as temp
 
 #show: temp.with(
-  title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
+  title-ja: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
   title-en: [How to Write a Conference Paper in Japanese],
-  authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
+  authors-ja: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
   authors-en: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),

--- a/main.typ
+++ b/main.typ
@@ -32,8 +32,22 @@
 //   latin-font: latin
 // )
 
-#import "libs/rengo/lib.typ": rengo
-#show: rengo.with(
+// #import "libs/rengo/lib.typ": rengo
+// #show: rengo.with(
+//   title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
+//   authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
+//   etitle: [How to Write a Conference Paper in Japanese],
+//   eauthors: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
+//   abstract: [#lorem(80)],
+//   keywords: ([Typst], [conference paper writing], [manuscript format]),
+//   bibliography: bibliography("refs.yml", full: false),
+//   gothic-font: gothic,
+//   mincho-font: mincho,
+//   latin-font: latin
+// )
+
+#import "libs/mscs/lib.typ": mscs
+#show: mscs.with(
   title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
   authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
   etitle: [How to Write a Conference Paper in Japanese],
@@ -45,17 +59,6 @@
   mincho-font: mincho,
   latin-font: latin
 )
-
-// #import "libs/mscs/lib.typ": mscs, gothic
-// #show: mscs.with(
-//   title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
-//   authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
-//   etitle: [How to Write a Conference Paper in Japanese],
-//   eauthors: [\*A. First, B. Second (○○○ University), and C. Third (□□□ Corporation)],
-//   abstract: [#lorem(80)],
-//   keywords: ([Typst], [conference paper writing], [manuscript format]),
-//   bibliography: bibliography("refs.yml", full: false)
-// )
 
 // 定理環境
 #import "@preview/ctheorems:1.1.3": thmplain, thmproof, thmrules

--- a/main.typ
+++ b/main.typ
@@ -4,23 +4,26 @@
 // Set the Fonts
 // #let gothic = ("BIZ UDPGothic", "MS PGothic", "Hiragino Kaku Gothic Pro", "IPAexGothic", "Noto Sans CJK JP")
 // #let mincho = ("BIZ UDPMincho", "MS PMincho", "Hiragino Mincho Pro", "IPAexMincho", "Noto Serif CJK JP")
-// #let english = ("Times New Roman", "New Computer Modern")
+// #let latin = ("Times New Roman", "New Computer Modern")
+// This may warn of missing font families.
+// Warnings can be resolved by setting the following for each OS.
 
 // example 1: Windows
 // #let gothic = ("MS PGothic")
 // #let mincho = ("MS PMincho")
-// #let english = ("Times New Roman")
+// #let latin = ("Times New Roman")
 
 // example 2: Mac OS
 // #let gothic = ("Hiragino Kaku Gothic Pro")
 // #let mincho = ("Hiragino Mincho Pro")
-// #let english = ("Times New Roman")
+// #let latin = ("Times New Roman")
 
 // example 3: Linux or Typst app
 #let gothic = ("Noto Sans CJK JP")
 #let mincho = ("Noto Serif CJK JP")
 #let latin = ("New Computer Modern")
 
+// Select the Template
 #import "libs/rsj-conf/lib.typ": rsj-conf as temp
 // #import "libs/rengo/lib.typ": rengo as temp
 // #import "libs/mscs/lib.typ": mscs as temp

--- a/main.typ
+++ b/main.typ
@@ -1,12 +1,35 @@
 // MIT No Attribution
 // Copyright 2024 Shunsuke Kimura
 
-#import "libs/rsj-conf/lib.typ": rsj-conf, gothic
+// Set the Fonts
+// #let gothic = ("BIZ UDPGothic", "MS PGothic", "Hiragino Kaku Gothic Pro", "IPAexGothic", "Noto Sans CJK JP")
+// #let mincho = ("BIZ UDPMincho", "MS PMincho", "Hiragino Mincho Pro", "IPAexMincho", "Noto Serif CJK JP")
+// #let english = ("Times New Roman", "New Computer Modern")
+
+// example 1: Windows
+// #let gothic = ("MS PGothic")
+// #let mincho = ("MS PMincho")
+// #let english = ("Times New Roman")
+
+// example 2: Mac OS
+// #let gothic = ("Hiragino Kaku Gothic Pro")
+// #let mincho = ("Hiragino Mincho Pro")
+// #let english = ("Times New Roman")
+
+// example 3: Linux or Typst app
+#let gothic = ("Noto Sans CJK JP", "IPAexGothic")
+#let mincho = ("Noto Serif CJK JP")
+#let latin = ("New Computer Modern")
+
+#import "libs/rsj-conf/lib.typ": rsj-conf
 #show: rsj-conf.with(
   title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
   authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
   abstract: [#lorem(80)],
-  bibliography: bibliography("refs.yml", full: false)
+  bibliography: bibliography("refs.yml", full: false),
+  gothic-font: gothic,
+  mincho-font: mincho,
+  latin-font: latin
 )
 
 // #import "libs/rengo/lib.typ": rengo, gothic
@@ -31,10 +54,6 @@
 //   bibliography: bibliography("refs.yml", full: false)
 // )
 
-// ソースコードブロックを表示するためのパッケージ
-#import "@preview/sourcerer:0.2.1": code
-// #import "libs/sourcerer-0.2.1/src/lib.typ": code // 2.3.1 を参照
-
 // 定理環境
 #import "@preview/ctheorems:1.1.3": thmplain, thmproof, thmrules
 // #import "libs/ctheorems-1.1.3/lib.typ": thmplain, thmproof, thmrules  // 2.3.1 を参照
@@ -44,8 +63,11 @@
 #let theorem = thmjp("theorem", text(font: gothic)[定理])
 #let corollary = thmjp("corollary",text(font: gothic)[系])
 #let proof = thmproof("proof", text(font: gothic)[証明], separator: [#h(0.9em)], titlefmt: strong, inset: (top: 0em, left: 0em))
-// Theorem environment
 #show: thmrules.with(qed-symbol: $square$)
+
+// ソースコードブロックを表示するためのパッケージ
+#import "@preview/codly:1.1.1": codly-init
+#show: codly-init.with()
 
 = はじめに
 #text("これは非公式のサンプルです．", fill: rgb(red), weight: "bold")
@@ -75,37 +97,29 @@ VS Code の拡張機能である Tinymist Typst をインストールすれば�
 
 === インストール
 - Windows の場合\ Windows PowerShell から以下のコマンドでインストールできる．
-#code(
-  ```sh
-  winget install --id Typst.Typst
-  ```
-)
+```sh
+winget install --id Typst.Typst
+```
 - Mac の場合\ Homebrew を使ってインストールできる．
-#code(
-  ```sh
-  # Homebrew のインストール
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  # Typst のインストール
-  brew install typst
-  ```
-)
+```sh
+# Homebrew のインストール
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# Typst のインストール
+brew install typst
+```
 - Rust からインストール\ たとえば Ubuntu の場合は，Rust の cargo を使ってインストールする方法が簡単と思われます．
-#code(
-  ```sh
-  # Rust のインストール
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-  # Typst のインストール
-  cargo install --git https://github.com/typst/typst --locked typst-cli
-  ```
-)
+```sh
+# Rust のインストール
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+# Typst のインストール
+cargo install --git https://github.com/typst/typst --locked typst-cli
+```
 
 === ビルド
 シェルで対象のディレクトリに移り
-#code(
-  ```sh
-  typst compile main.typ
-  ```
-)
+```sh
+typst compile main.typ
+```
 とコマンドすれば main.pdf をビルドできます．
 
 == このパッケージが使えない場合
@@ -119,17 +133,15 @@ VS Code の拡張機能である Tinymist Typst をインストールすれば�
 - https://typst.app/universe/package/sourcerer
 - https://typst.app/universe/package/ctheorems
 これらの圧縮ファイルを main.typ と同じフォルダーにある libs フォルダーの中に展開した後，以下のようにコメントアウトを付け替えて，それぞれの lib.typ ファイルへのパスを指定する．
-#code(
-  ```typst
-    // ソースコードブロックを表示するためのパッケージ
-    // #import "@preview/sourcerer:0.2.1": code
-    #import "libs/sourcerer-0.2.1/src/lib.typ": code // 2.3.1 を参照
+```typst
+  // ソースコードブロックを表示するためのパッケージ
+  #import "@preview/codly:1.1.1": codly-init
+  #show: codly-init.with()
 
-    // 定理環境
-    // #import "@preview/ctheorems:1.1.3": thmplain, thmproof, thmrules
-    #import "libs/ctheorems-1.1.3/lib.typ": thmplain, thmproof, thmrules  // 2.3.1 を参照
-  ```
-)
+  // 定理環境
+  // #import "@preview/ctheorems:1.1.3": thmplain, thmproof, thmrules
+  #import "libs/ctheorems-1.1.3/lib.typ": thmplain, thmproof, thmrules  // 2.3.1 を参照
+```
 
 = 原稿の体裁
 
@@ -143,11 +155,9 @@ VS Code の拡張機能である Tinymist Typst をインストールすれば�
 ここで，ゴシック体とは "BIZ UDPGothic", "MS PGothic", "Hiragino Kaku Gothic Pro", "IPAexGothic", "Noto Sans CJK JP" のいずれか，明朝体とは "BIZ UDPMincho", "MS PMincho", "Hiragino Mincho Pro", "IPAexMincho", "Noto Serif CJK JP" のいずれかで見つかるものが採用されます．
 これらのフォントがお使いのコンピュータになければインストールするか，代わりに使いたいフォントがあればソースコードの方に追加してください．
 以下のコマンドで使用可能なフォント一覧を確認できます．
-#code(
-  ```sh
-  typst fonts
-  ```
-)
+```sh
+typst fonts
+```
 
 #figure(
   placement: bottom,
@@ -208,17 +218,15 @@ VS Code の拡張機能である Tinymist Typst をインストールすれば�
 
 == 論文情報の編集
 main.typ の文頭にある以下のコードを解説します．
-#code(
-  ```typ
-    #import "libs/rsj-conf/lib.typ": rsj-conf
-    #show: rsj-conf.with(
-      title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
-      authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
-      abstract: [#lorem(80)],
-      bibliography: bibliography("refs.yml", full: false)
-    )
-  ```
-)
+```typ
+  #import "libs/rsj-conf/lib.typ": rsj-conf
+  #show: rsj-conf.with(
+    title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
+    authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
+    abstract: [#lorem(80)],
+    bibliography: bibliography("refs.yml", full: false)
+  )
+```
 1 行目はこの原稿の体裁を設定するためのソースコードを import しています．
 これは "libs" ディレクトリ以下にあります．
 2 行目は，ソースコードやコマンドなどを綺麗に表示するための "code" 関数を呼び出すために import しています．
@@ -235,20 +243,18 @@ Typst Universe から自動でインストールされたものを使ってお�
 
 また，異なるテンプレートも用意してみました．
 コメントアウトで切り替えてみてください．
-#code(
-  ```typ
-    #import "libs/rengo/lib.typ": rengo
-    #show: rengo.with(
-      title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
-      authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
-      etitle: [How to write a conference paper in Japanese],
-      eauthors: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
-      abstract: [#lorem(80)],
-      keywords: ([Typst], [conference paper writing], [manuscript format]),
-      bibliography: bibliography("refs.yml", full: false)
-    )
-  ```
-)
+```typ
+  #import "libs/rengo/lib.typ": rengo
+  #show: rengo.with(
+    title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
+    authors: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
+    etitle: [How to write a conference paper in Japanese],
+    eauthors: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
+    abstract: [#lorem(80)],
+    keywords: ([Typst], [conference paper writing], [manuscript format]),
+    bibliography: bibliography("refs.yml", full: false)
+  )
+```
 このフォーマットですと，`etitle`, `eauthors`, `keywords` が追加されており，それぞれ英語タイトル，英語著者名，キーワードを意味しています．
 `keywords` は`()` のリスト形式で指定されていることに注意してください．
 
@@ -263,18 +269,14 @@ LaTeX に慣れている方は，Typst 公式ページの https://typst.app/docs
 
 == 数式
 数式番号をつけるような中央揃えの数式は，最初の`$` の後ろと閉じの`$` の前にスペースを挟み
-#code(
-  ```typ
-    $ dot(x) &= A x + B u \
-    y &= C x $ <eq:system>
-  ```
-)
+```typ
+  $ dot(x) &= A x + B u \
+  y &= C x $ <eq:system>
+```
 のように書き，文中に書く数式は，`$` の前後にスペースを挟まず
-#code(
-  ```typ
-    $x in RR^n$
-  ```
-)
+```typ
+  $x in RR^n$
+```
 というように書きます．
 ここで `<eq:system>` は引用するときのラベルになります．
 
@@ -290,21 +292,19 @@ $ u = K_P e + K_I integral_0^t e d t $ <eq:PI-controller>
 == 図と表
 本稿を執筆時のバージョン Typst 0.11.0 では，PNG, JPEG, GIF, SVG の形式のイメージデータを挿入することができます．
 例としては以下の通りです．
-#code(
-  ```typ
-    #figure(
-      placement: bottom,
-      image("figs/quadratic.svg", width: 90%),
-      caption: [$x^2$ のグラフ],
-    ) <fig:quadratic>
+```typ
+  #figure(
+    placement: bottom,
+    image("figs/quadratic.svg", width: 90%),
+    caption: [$x^2$ のグラフ],
+  ) <fig:quadratic>
 
-    #figure(
-      placement: bottom,
-      image("figs/sqrt-and-sin.png", width: 90%),
-      caption: [$sqrt(x)$ と $sin x$ のグラフ],
-    ) <fig:sqrt-sin>
-  ```
-)
+  #figure(
+    placement: bottom,
+    image("figs/sqrt-and-sin.png", width: 90%),
+    caption: [$sqrt(x)$ と $sin x$ のグラフ],
+  ) <fig:sqrt-sin>
+```
 ここで placement は，紙面の上 (top) に寄せるか下 (bottom) に寄せるかを決められます．言及している文章に近い方に調整してください．
 
 #figure(
@@ -320,86 +320,76 @@ $ u = K_P e + K_I integral_0^t e d t $ <eq:PI-controller>
 ) <fig:sqrt-sin>
 
 @tab:fonts は以下で記述されております．
-#code(
-  ```typ
-    #figure(
-      placement: top,
-      caption: [フォントの設定],
-      table(
-        columns: 3,
-        stroke: none,
-        table.header(
-          [項目],
-          [サイズ (pt)],
-          [フォント],
-        ),
-        table.hline(),
-        [#text(18pt, "タイトル", font: gothic)], [18], [ゴシック体],
-        [#text(12pt, "著者名", font: gothic)], [12], [ゴシック体],
-        [#text(12pt, "章タイトル")], [12], [ゴシック体],
-        [節，小節，本文], [10], [明朝体],
-        [#text(9pt, "参考文献")], [9], [明朝体],
-      )
-    ) <tab:fonts>
-  ```
-)
+```typ
+  #figure(
+    placement: top,
+    caption: [フォントの設定],
+    table(
+      columns: 3,
+      stroke: none,
+      table.header(
+        [項目],
+        [サイズ (pt)],
+        [フォント],
+      ),
+      table.hline(),
+      [#text(18pt, "タイトル", font: gothic)], [18], [ゴシック体],
+      [#text(12pt, "著者名", font: gothic)], [12], [ゴシック体],
+      [#text(12pt, "章タイトル")], [12], [ゴシック体],
+      [節，小節，本文], [10], [明朝体],
+      [#text(9pt, "参考文献")], [9], [明朝体],
+    )
+  ) <tab:fonts>
+```
 table の columns の数に応じて，文字列の配列が自動的に整列されます．
 `stroke: none` は枠線を消しています．`table.hline()` を挟むとその位置に横線を引けます．
 ここで，`gothic` は `lib.typ` で定義されています．
 他のテンプレートを使用する場合には注意をしてください．
-#code(
-  ```typ
-    #import "libs/rsj-conf/lib.typ": rsj-conf, gothic
-  ```
-)
+```typ
+  #import "libs/rsj-conf/lib.typ": rsj-conf, gothic
+```
 
 == 定理環境
 @def:definition1 や @lem:lemma1 などは以下で記述されております．
 
-#code(
-  ```typ
-    #definition("用語 A")[
-      用語 A の定義を書きます．
-    ]<def:definition1>
-    #lemma[
-      補題を書きます．タイトルは省略することもできます．
-    ]<lem:lemma1>
-    #lemma("補題 C")[
-      補題を書きます．番号は定義や補題ごとに 1 からカウントします．
-    ]<lem:lemma2>
-    #theorem("定理 D")[
-      ここに定理を書きます．
-    ]<thm:theorem1>
-    #corollary[
-      系を書きます．@def:definition1 のように，ラベルで参照することもできます．
-    ]
-    #proof([@thm:theorem1 の証明])[
-      証明を書きます．証明終了として□印をつけています．
-    ]
-  ```
-)
+```typ
+  #definition("用語 A")[
+    用語 A の定義を書きます．
+  ]<def:definition1>
+  #lemma[
+    補題を書きます．タイトルは省略することもできます．
+  ]<lem:lemma1>
+  #lemma("補題 C")[
+    補題を書きます．番号は定義や補題ごとに 1 からカウントします．
+  ]<lem:lemma2>
+  #theorem("定理 D")[
+    ここに定理を書きます．
+  ]<thm:theorem1>
+  #corollary[
+    系を書きます．@def:definition1 のように，ラベルで参照することもできます．
+  ]
+  #proof([@thm:theorem1 の証明])[
+    証明を書きます．証明終了として□印をつけています．
+  ]
+```
 
 ここで，`definition`, `lemma`, `theorem`, `corollary`, `proof` は `gothic` と同様に `lib.typ` で定義されています．
 他のテンプレートを使用する場合には注意をしてください．
-#code(
-  ```typ
-    #import "libs/rsj-conf/lib.typ": rsj-conf, gothic
-  ```
-)
+```typ
+  #import "libs/rsj-conf/lib.typ": rsj-conf, gothic
+```
 さらに元をたどると `lib.typ` で ctheorems パッケージ (https://typst.app/universe/package/ctheorems) をインポートして使用しております．
 
-#code(
-  ```typ
-    // Theorem environment
-    #import "@preview/ctheorems:1.1.3": thmplain, thmproof, thmrules
-    #let thmjp = thmplain.with(base: {}, separator: [#h(0.5em)], titlefmt: strong, inset: (top: 0em, left: 0em))
-    #let definition = thmjp("definition", text(font: gothic)[定義])
-    #let lemma = thmjp("lemma",text(font: gothic)[補題])
-    #let theorem = thmjp("theorem", text(font: gothic)[定理])
-    #let corollary = thmjp("corollary",text(font: gothic)[系])
-    #let proof = thmproof("proof", text(font: gothic)[証明], separator: [#h(0.9em)], titlefmt: strong, inset: (top: 0em, left: 0em))
-  ```
-)
+```typ
+  // Theorem environment
+  #import "@preview/ctheorems:1.1.3": thmplain, thmproof, thmrules
+  #let thmjp = thmplain.with(base: {}, separator: [#h(0.5em)], titlefmt: strong, inset: (top: 0em, left: 0em))
+  #let definition = thmjp("definition", text(font: gothic)[定義])
+  #let lemma = thmjp("lemma",text(font: gothic)[補題])
+  #let theorem = thmjp("theorem", text(font: gothic)[定理])
+  #let corollary = thmjp("corollary",text(font: gothic)[系])
+  #let proof = thmproof("proof", text(font: gothic)[証明], separator: [#h(0.9em)], titlefmt: strong, inset: (top: 0em, left: 0em))
+```
 
 == 参考文献
 参考文献は `refs.yml` に記載してください．


### PR DESCRIPTION
Typst 0.12 になってからフォントが見つからない場合に警告が出るようになっていたため、それを修正した。

- フォントを引数として変更できるようにした。`font-gothic`, `font-mincho`, `font-latin`
- 上記の引数に合わせて、タイトルや著者の引数も変更した。`title-ja`, `title-en`, `authors-ja`, `authors-en`
- コードを表示する関数である`sourcerer`が更新されないため、`codly`に変更した。