### PR TITLE
RSJの参考文献リストの指定の仕方を変更

### DIFF
--- a/libs/mscs/lib.typ
+++ b/libs/mscs/lib.typ
@@ -23,8 +23,9 @@
     margin: (top: 20mm, bottom: 27mm, x: 20mm)
   )
   set text(size: 10pt, font: font-mincho)
-  // show regex("[0-9a-zA-Z]"): set text(font: "New Computer Modern Math")
   set par(leading: 0.55em, first-line-indent: 1em, justify: true, spacing: 0.55em)
+  show "、": "，"
+  show "。": "．"
 
   // Configure equation numbering and spacing.
   set math.equation(numbering: "(1)")
@@ -66,18 +67,18 @@
       #set text(if is-ack { 11pt } else { 11pt }, font: font-gothic)
       #v(20pt, weak: true)
       #if it.numbering != none and not is-ack {
-        numbering("1.", ..levels)
+        numbering(it.numbering, ..levels)
         h(8pt, weak: true)
       }
       #it.body
-      #v(13.75pt, weak: true)
+      #v(8pt, weak: true)
     ] else [
       // The other level headings are run-ins.
       #set par(first-line-indent: 0pt)
       #set text(10pt, weight: 400)
-      #v(10pt, weak: true)
+      #v(8pt, weak: true)
       #if it.numbering != none {
-        numbering("1.", ..levels)
+        numbering(it.numbering, ..levels)
         h(8pt, weak: true)
       }
       #it.body

--- a/libs/rengo/lib.typ
+++ b/libs/rengo/lib.typ
@@ -25,6 +25,8 @@
   set text(size: 10pt, font: font-mincho)
   // show regex("[0-9a-zA-Z]"): set text(font: "New Computer Modern Math")
   set par(leading: 0.55em, first-line-indent: 1em, justify: true, spacing: 0.55em)
+  show "、": "，"
+  show "。": "．"
 
   // Configure equation numbering and spacing.
   set math.equation(numbering: "(1)")

--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -25,6 +25,8 @@
 
   set text(size: 10pt, font: font-mincho)
   set par(leading: 0.55em, first-line-indent: 1em, justify: true, spacing: 0.55em)
+  show "、": "，"
+  show "。": "．"
 
   // Configure equation numbering and spacing.
   set math.equation(numbering: "(1)")

--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -18,8 +18,7 @@
     paper: "a4",
     margin: (top: 20mm, bottom: 27mm, x: 20mm)
   )
-
-  set text(size: 10pt, font: font-mincho)
+  set text(size: 10pt, lang: "ja", font: font-mincho)
   set par(leading: 0.55em, first-line-indent: 1em, justify: true, spacing: 0.55em)
   show "、": "，"
   show "。": "．"
@@ -104,9 +103,12 @@
   show: columns.with(2, gutter: 8mm)
 
   // Configure Bibliography.
-  show bibliography: set text(9pt)
-  // show regex("[0-9a-zA-Z]"): set text(font: font-latin)
-  set bibliography(title:  align(center, text(11pt)[参　考　文　献]), style: "rsj-conf.csl")
+  set bibliography(title: align(center, text(11pt)[参　考　文　献]), style: "rsj-conf.csl")
+  show bibliography: it => [
+    #set text(9pt,lang: "en", font: font-mincho)
+    #show regex("[0-9a-zA-Z]"): set text(font: font-latin)
+    #it
+  ]
 
   // Display the paper's contents.
   body

--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -1,14 +1,10 @@
-// Workaround for the lack of an `std` scope.
-#let std-bibliography = bibliography
-
 #let rsj-conf(
-  title-ja: [タイトル],
+  title-ja: [日本語タイトル],
   title-en: [],
   authors-ja: [著者],
   authors-en: [],
   abstract: none,
   keywords: (),
-  bibliography: none,
   font-gothic: "BIZ UDPGothic",
   font-mincho: "BIZ UDPMincho",
   font-latin: "New Computer Modern",
@@ -33,15 +29,14 @@
   show math.equation: set block(spacing: 0.55em)
 
   // Configure appearance of equation references
+  // See https://typst.app/docs/reference/model/ref/
   show ref: it => {
     if it.element != none and it.element.func() == math.equation {
-      // Override equation references.
       link(it.element.location(), numbering(
         it.element.numbering,
         ..counter(math.equation).at(it.element.location())
       ))
     } else {
-      // Other references as usual.
       it
     }
   }
@@ -55,35 +50,26 @@
   show heading: it => {
     // Find out the final number of the heading counter.
     let levels = counter(heading).get()
-    let deepest = if levels != () {
-      levels.last()
-    } else {
-      1
-    }
     if it.level == 1 [
-      // First-level headings are centered smallcaps.
       // We don't want to number of the acknowledgment section.
       #set par(first-line-indent: 0pt)
-      #let is-ack = it.body in ([謝辞], [Acknowledgment], [Acknowledgement])
-      #set text(if is-ack { 11pt } else { 11pt }, font: font-gothic)
+      #set text(font: font-gothic)
       #v(20pt, weak: true)
-      #if it.numbering != none and not is-ack {
-        numbering("1.", ..levels)
+      #if it.numbering != none and not it.body in ([謝辞], [Acknowledgment], [Acknowledgement]) {
+        numbering(it.numbering, ..levels)
         h(8pt, weak: true)
       }
       #it.body
-      #v(10pt, weak: true)
     ] else [
       // The other level headings are run-ins.
       #set par(first-line-indent: 0pt)
       #set text(10pt, weight: 400)
       #v(10pt, weak: true)
       #if it.numbering != none {
-        numbering("1.", ..levels)
+        numbering(it.numbering, ..levels)
         h(8pt, weak: true)
       }
       #it.body
-      #v(10pt, weak: true)
     ]
   }
 
@@ -117,14 +103,11 @@
   // Start two column mode and configure paragraph properties.
   show: columns.with(2, gutter: 8mm)
 
+  // Configure Bibliography.
+  show bibliography: set text(9pt)
+  // show regex("[0-9a-zA-Z]"): set text(font: font-latin)
+  set bibliography(title:  align(center, text(11pt)[参　考　文　献]), style: "rsj-conf.csl")
+
   // Display the paper's contents.
   body
-
-  // Display bibliography.
-  if bibliography != none {
-    show std-bibliography: set text(9pt)
-    show regex("[0-9a-zA-Z]"): set text(font: font-latin)
-    set std-bibliography(title:  align(center, text(11pt)[参　考　文　献]), style: "rsj-conf.csl")
-    bibliography
-  }
 }

--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -53,7 +53,7 @@
     if it.level == 1 [
       // We don't want to number of the acknowledgment section.
       #set par(first-line-indent: 0pt)
-      #set text(font: font-gothic)
+      #set text(11pt, font: font-gothic)
       #v(20pt, weak: true)
       #if it.numbering != none and not it.body in ([謝辞], [Acknowledgment], [Acknowledgement]) {
         numbering(it.numbering, ..levels)

--- a/main.typ
+++ b/main.typ
@@ -29,13 +29,13 @@
 // #import "libs/mscs/lib.typ": mscs as temp
 
 #show: temp.with(
-  title-ja: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ], 
+  title-ja: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ],
   title-en: [How to Write a Conference Paper in Japanese],
-  authors-ja: [◯ 著者姓1 著者名1，著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
+  authors-ja: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)，著者姓3 著者名3 (□□□株式会社)],
   authors-en: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),
-  bibliography: bibliography("refs.yml", full: false),
+  // bibliography: bibliography("refs.yml", full: false),
   font-gothic: gothic,
   font-mincho: mincho,
   font-latin: latin
@@ -57,9 +57,9 @@
 #show: codly-init.with()
 
 = はじめに
-#text("これは非公式のサンプルです．", fill: rgb(red), weight: "bold")
-適宜投稿先の規定をご確認ください．
-発表論文原稿を PDF でご執筆いただき，学会のホームページにアップロードしてください．
+#text("これは非公式のサンプルです。", fill: rgb(red), weight: "bold")
+適宜投稿先の規定をご確認ください。
+発表論文原稿をPDFでご執筆いただき、学会のホームページにアップロードしてください。
 このファイルはこのテンプレートの使い方を示しており，同時に発表論文の見本でもあります．
 執筆の時は以下の説明をよく読み，執筆要項に従ったフォーマットでご提出ください．
 アップロードした PDF がそのまま公開されます．
@@ -120,7 +120,7 @@ typst compile main.typ
 - https://typst.app/universe/package/sourcerer
 - https://typst.app/universe/package/ctheorems
 これらの圧縮ファイルを main.typ と同じフォルダーにある libs フォルダーの中に展開した後，以下のようにコメントアウトを付け替えて，それぞれの lib.typ ファイルへのパスを指定する．
-```typst
+```typ
   // ソースコードブロックを表示するためのパッケージ
   #import "@preview/codly:1.1.1": codly-init
   #show: codly-init.with()
@@ -412,3 +412,5 @@ CSL ファイルは著者が編集する必要はありませんが，詳細が�
 「この研究は☆☆☆の助成を受けて行われました．」や「〇〇〇大学との共同研究です．」
 みたいな文章が書かれることを想定しています．
 最後までお読みいただき誠にありがとうございました．
+
+#bibliography("refs.yml", full: false)


### PR DESCRIPTION
テンプレートの引数から取り除き、main.typの末尾で呼び出すように変更しました。
**RSJのテンプレートのみを変更しています。他のテンプレートについては別PRで対応予定です。**