### PR TITLE
Feature: font state

### DIFF
--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -2,6 +2,19 @@
 #let font-size-heading = 11pt
 #let state-font-gothic = state("gothic", "BIZ UDPGothic")
 
+// import third-party packages
+#import "@preview/ctheorems:1.1.3": thmplain, thmproof, thmrules
+#import "@preview/codly:1.1.1": codly-init
+
+// Theorem environments
+#let thmjp = thmplain.with(base: {}, separator: [#h(0.5em)], titlefmt: strong, inset: (top: 0em, left: 0em))
+#let definition = thmjp("definition", context{text(font: state-font-gothic.get())[定義]})
+#let lemma = thmjp("lemma", context{text(font: state-font-gothic.get())[補題]})
+#let theorem = thmjp("theorem", context{text(font: state-font-gothic.get())[定理]})
+#let corollary = thmjp("corollary", context{text(font: state-font-gothic.get())[系]})
+#let proof = thmproof("proof", context{text(font: state-font-gothic.get())[証明]}, separator: [#h(0.9em)], titlefmt: strong, inset: (top: 0em, left: 0em))
+
+// Configuration for the RSJ Conference paper.
 #let rsj-conf(
   title-ja: [日本語タイトル],
   title-en: [],
@@ -14,7 +27,13 @@
   font-latin: "New Computer Modern",
   body
 ) = {
+  // Set the font for headings.
   state-font-gothic.update(font-gothic)
+
+  // Enable ctheorems.
+  show: thmrules.with(qed-symbol: $square$)
+  show: codly-init.with()
+
   // Set document metadata.
   set document(title: title-ja)
 
@@ -119,6 +138,7 @@
   body
 }
 
+// Appendix
 #let appendix(body) = {
   set heading(numbering: "A.1", supplement: [付録])
   counter(heading).update(0)

--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -54,27 +54,27 @@
   show heading: it => {
     // Find out the final number of the heading counter.
     let levels = counter(heading).get()
-    if it.level == 1 [
+    if it.level == 1 {
       // We don't want to number of the acknowledgment section.
-      #set par(first-line-indent: 0pt)
-      #set text(font-size-heading, font: font-gothic)
-      #v(10pt)
-      #if it.numbering != none and not it.body in ([謝辞], [Acknowledgment], [Acknowledgement]) {
+      set par(first-line-indent: 0pt)
+      set text(font-size-heading, font: font-gothic)
+      v(10pt)
+      if it.numbering != none and not it.body in ([謝辞], [Acknowledgment], [Acknowledgement]) {
         numbering(it.numbering, ..levels)
         h(5pt)
       }
-      #it.body
-    ] else [
+      it.body
+     } else {
       // The other level headings are run-ins.
-      #set par(first-line-indent: 0pt)
-      #set text(font-size-default, weight: 400)
-      #v(5pt)
-      #if it.numbering != none {
+      set par(first-line-indent: 0pt)
+      set text(font-size-default, weight: 400)
+      v(5pt)
+      if it.numbering != none {
         numbering(it.numbering, ..levels)
         h(8pt, weak: true)
       }
-      #it.body
-    ]
+      it.body
+    }
   }
 
   show figure.where(kind: table): set figure(placement: top, supplement: [表])

--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -1,5 +1,6 @@
 #let font-size-default = 10pt
 #let font-size-heading = 11pt
+#let state-font-gothic = state("gothic", "BIZ UDPGothic")
 
 #let rsj-conf(
   title-ja: [日本語タイトル],
@@ -13,6 +14,7 @@
   font-latin: "New Computer Modern",
   body
 ) = {
+  state-font-gothic.update(font-gothic)
   // Set document metadata.
   set document(title: title-ja)
 
@@ -117,7 +119,7 @@
   body
 }
 
-#let appendix(font-gothic: "Noto Sans CJK JP", body) = {
+#let appendix(body) = {
   set heading(numbering: "A.1", supplement: [付録])
   counter(heading).update(0)
   counter(figure.where(kind: image)).update(0)
@@ -126,6 +128,6 @@
     [#numbering("A", counter(heading).get().at(0)).#it]
   })
   v(20pt, weak: true)
-  text(font-size-heading, font: font-gothic, weight: "bold")[付　　録]
+  context(text(font-size-heading, font: state-font-gothic.get(), weight: "bold")[付　　録])
   body
 }

--- a/main.typ
+++ b/main.typ
@@ -24,9 +24,9 @@
 #let latin = ("New Computer Modern")
 
 // Select the Template
-#import "libs/rsj-conf/lib.typ": rsj-conf as temp, appendix
-// #import "libs/rengo/lib.typ": rengo as temp
-// #import "libs/mscs/lib.typ": mscs as temp
+#import "libs/rsj-conf/lib.typ": rsj-conf as temp, definition, lemma, theorem, corollary, proof, appendix
+// #import "libs/rengo/lib.typ": rengo as temp, definition, lemma, theorem, corollary, proof, appendix
+// #import "libs/mscs/lib.typ": mscs as temp, definition, lemma, theorem, corollary, proof, appendix
 
 #show: temp.with(
   title-ja: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ],
@@ -40,21 +40,6 @@
   font-mincho: mincho,
   font-latin: latin
 )
-
-// 定理環境
-#import "@preview/ctheorems:1.1.3": thmplain, thmproof, thmrules
-// #import "libs/ctheorems-1.1.3/lib.typ": thmplain, thmproof, thmrules  // 2.3.1 を参照
-#let thmjp = thmplain.with(base: {}, separator: [#h(0.5em)], titlefmt: strong, inset: (top: 0em, left: 0em))
-#let definition = thmjp("definition", text(font: gothic)[定義])
-#let lemma = thmjp("lemma",text(font: gothic)[補題])
-#let theorem = thmjp("theorem", text(font: gothic)[定理])
-#let corollary = thmjp("corollary",text(font: gothic)[系])
-#let proof = thmproof("proof", text(font: gothic)[証明], separator: [#h(0.9em)], titlefmt: strong, inset: (top: 0em, left: 0em))
-#show: thmrules.with(qed-symbol: $square$)
-
-// ソースコードブロックを表示するためのパッケージ
-#import "@preview/codly:1.1.1": codly-init
-#show: codly-init.with()
 
 = はじめに
 #text("これは非公式のサンプルです。", fill: rgb(red), weight: "bold")
@@ -158,8 +143,8 @@ typst fonts
       [フォント],
     ),
     table.hline(),
-    [#text(18pt, "タイトル", font: gothic)], [18], [ゴシック体],
-    [#text(12pt, "著者名", font: gothic)], [12], [ゴシック体],
+    [#text(18pt, "タイトル")], [18], [ゴシック体],
+    [#text(12pt, "著者名")], [12], [ゴシック体],
     [#text(12pt, "章タイトル")], [12], [ゴシック体],
     [節，小節，本文], [10], [明朝体],
     [#text(9pt, "参考文献")], [9], [明朝体],
@@ -320,8 +305,8 @@ $ u = K_P e + K_I integral_0^t e d t $ <eq:PI-controller>
         [フォント],
       ),
       table.hline(),
-      [#text(18pt, "タイトル", font: gothic)], [18], [ゴシック体],
-      [#text(12pt, "著者名", font: gothic)], [12], [ゴシック体],
+      [#text(18pt, "タイトル")], [18], [ゴシック体],
+      [#text(12pt, "著者名")], [12], [ゴシック体],
       [#text(12pt, "章タイトル")], [12], [ゴシック体],
       [節，小節，本文], [10], [明朝体],
       [#text(9pt, "参考文献")], [9], [明朝体],


### PR DESCRIPTION
RSJのみ対応。
`state-font-gothic`を通してフォント情報を異なる関数間でも共有することができました。
それにともない、サードパーティ製パッケージのインポートや設定をmain.typからlib.typに移します。