### PR TITLE
remove: ja form title and authors

### DIFF
--- a/jaconf/README.md
+++ b/jaconf/README.md
@@ -21,10 +21,10 @@ This is a template for **academic conference papers in Japanese**.
 このテンプレートが提供する `jaconf` 関数は、以下の名前付き引数を持ちます。
 
 - 基本　Basic
-  - `title-ja`: 日本語タイトル。
+  - `tilte`: 日本語タイトル。
   - `title-en`: 英語タイトル。
-  - `authors-ja`: 日本語著者名とその所属。
-  - `authors-ja`: 英語著者名とその所属。
+  - `authors`: 日本語著者名とその所属。
+  - `authors`: 英語著者名とその所属。
   - `abstract`: 概要。
   - `keywords`: キーワード。配列で渡してください。
 - フォント名
@@ -46,9 +46,9 @@ This is a template for **academic conference papers in Japanese**.
   - `heading-bibliography`: 参考文献の見出し
   - `heading-appendix`: 付録の見出し
 - フォントサイズ　Font size
-  - `font-size-title-ja`: 日本語タイトルのフォントサイズ
+  - `font-size-tilte`: 日本語タイトルのフォントサイズ
   - `font-size-title-en`: 英語タイトルのフォントサイズ
-  - `font-size-authors-ja`: 日本語著者名のフォントサイズ
+  - `font-size-authors`: 日本語著者名のフォントサイズ
   - `font-size-authors-en`: 英語著者名のフォントサイズ
   - `font-size-abstract`: 概要のフォントサイズ
   - `font-size-heading`: 見出しのフォントサイズ
@@ -71,9 +71,9 @@ This is a template for **academic conference papers in Japanese**.
 // デフォルト値でよい引数は省略可能
 #show: jaconf.with(
   // 基本 Basic
-  title-ja: [日本語の学会論文Typstテンプレート \ jaconf ],
+  tilte: [日本語の学会論文Typstテンプレート \ jaconf ],
   title-en: [How to Write a Conference Paper in Japanese],
-  authors-ja: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
+  authors: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
   authors-en: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),
@@ -96,9 +96,9 @@ This is a template for **academic conference papers in Japanese**.
   heading-bibliography: [参　考　文　献],
   heading-appendix: [付　録],
   // フォントサイズ Font size
-  font-size-title-ja: 16pt,
+  font-size-tilte: 16pt,
   font-size-title-en: 12pt,
-  font-size-authors-ja: 12pt,
+  font-size-authors: 12pt,
   font-size-authors-en: 12pt,
   font-size-abstract: 10pt,
   font-size-heading: 11pt,

--- a/jaconf/lib.typ
+++ b/jaconf/lib.typ
@@ -13,9 +13,9 @@
 
 #let jaconf(
   // 基本 Basic
-  title-ja: [日本語タイトル],
+  title: [日本語タイトル],
   title-en: [],
-  authors-ja: [著者],
+  authors: [著者],
   authors-en: [],
   abstract: none,
   keywords: (),
@@ -38,12 +38,12 @@
   heading-bibliography: [参　考　文　献],
   heading-appendix: [付　録],
   // フォントサイズ Font size
-  font-size-title-ja: 16pt,
+  font-size-title: 16pt,
   font-size-title-en: 12pt,
-  font-size-authors-ja: 12pt,
+  font-size-authors: 12pt,
   font-size-authors-en: 12pt,
   font-size-abstract: 10pt,
-  font-size-heading: 11pt,
+  font-size-heading: 12pt,
   font-size-main: 10pt,
   font-size-bibliography: 9pt,
   // 補足語 Supplement
@@ -66,7 +66,7 @@
   show: codly-init.with()
 
   // Set document metadata.
-  set document(title: title-ja)
+  set document(title: title)
 
   // Configure the page.
   set page(
@@ -136,11 +136,11 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: supplement-separator)
 
   // Display the paper's title.
-  align(center, text(font-size-title-ja, title-ja, weight: "bold", font: font-heading))
+  align(center, text(font-size-title, title, weight: "bold", font: font-heading))
   v(18pt, weak: true)
 
   // Display the authors list.
-  align(center, text(font-size-authors-ja, authors-ja, font: font-main))
+  align(center, text(font-size-authors, authors, font: font-main))
   v(1.5em, weak: true)
 
   // Display the paper's title in English.

--- a/jaconf/template/main.typ
+++ b/jaconf/template/main.typ
@@ -6,9 +6,9 @@
 // デフォルト値でよい引数は省略可能
 #show: jaconf.with(
   // 基本 Basic
-  title-ja: [日本語の学会論文Typstテンプレート \ jaconf ],
+  tilte: [日本語の学会論文Typstテンプレート \ jaconf ],
   title-en: [How to Write a Conference Paper in Japanese],
-  authors-ja: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
+  authors: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
   authors-en: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),
@@ -31,9 +31,9 @@
   heading-bibliography: [参　考　文　献],
   heading-appendix: [付　録],
   // フォントサイズ Font size
-  font-size-title-ja: 16pt,
+  font-size-tilte: 16pt,
   font-size-title-en: 12pt,
-  font-size-authors-ja: 12pt,
+  font-size-authors: 12pt,
   font-size-authors-en: 12pt,
   font-size-abstract: 10pt,
   font-size-heading: 11pt,

--- a/libs/mscs/lib.typ
+++ b/libs/mscs/lib.typ
@@ -5,9 +5,9 @@
 #import "@preview/jaconf:0.4.1": jaconf, definition, lemma, theorem, corollary, proof, appendix
 
 #let mscs(
-  title-ja: [日本語タイトル],
+  tilte: [日本語タイトル],
   title-en: [],
-  authors-ja: [著者],
+  authors: [著者],
   authors-en: [],
   abstract: none,
   keywords: (),
@@ -18,9 +18,9 @@
 ) = {
   show: jaconf.with(
     // 基本 Basic
-    title-ja: title-ja,
+    tilte: tilte,
     title-en: title-en,
-    authors-ja: authors-ja,
+    authors: authors,
     authors-en: authors-en,
     abstract: abstract,
     keywords: keywords,
@@ -34,7 +34,7 @@
     heading-bibliography: [#h(1em)参考文献],
     heading-appendix: [#h(1em)付録],
     // フォントサイズ Font size
-    font-size-title-ja: 18pt,
+    font-size-tilte: 18pt,
     // 補足語 Supplement
     supplement-image: [Fig.],
     supplement-table: [Table],

--- a/libs/rengo/lib.typ
+++ b/libs/rengo/lib.typ
@@ -5,9 +5,9 @@
 #import "@preview/jaconf:0.4.1": jaconf, definition, lemma, theorem, corollary, proof, appendix
 
 #let rengo(
-  title-ja: [日本語タイトル],
+  tilte: [日本語タイトル],
   title-en: [],
-  authors-ja: [著者],
+  authors: [著者],
   authors-en: [],
   abstract: none,
   keywords: (),
@@ -18,9 +18,9 @@
 ) = {
   show: jaconf.with(
     // 基本 Basic
-    title-ja: title-ja,
+    tilte: tilte,
     title-en: title-en,
-    authors-ja: authors-ja,
+    authors: authors,
     authors-en: authors-en,
     abstract: abstract,
     keywords: keywords,

--- a/libs/rsj-conf/lib.typ
+++ b/libs/rsj-conf/lib.typ
@@ -5,9 +5,9 @@
 #import "@preview/jaconf:0.4.1": jaconf, definition, lemma, theorem, corollary, proof, appendix as jaconf-appendix
 
 #let rsj-conf(
-  title-ja: [日本語タイトル],
+  tilte: [日本語タイトル],
   title-en: [],
-  authors-ja: [著者],
+  authors: [著者],
   authors-en: [],
   abstract: none,
   keywords: (),
@@ -19,9 +19,9 @@
 ) = {
   show: jaconf.with(
     // 基本 Basic
-    title-ja: title-ja,
+    tilte: tilte,
     title-en: title-en,
-    authors-ja: authors-ja,
+    authors: authors,
     authors-en: authors-en,
     abstract: abstract,
     keywords: (),

--- a/libs/sci/lib.typ
+++ b/libs/sci/lib.typ
@@ -5,9 +5,9 @@
 #import "@preview/jaconf:0.4.1": jaconf, definition, lemma, theorem, corollary, proof, appendix
 
 #let sci(
-  title-ja: [日本語タイトル],
+  tilte: [日本語タイトル],
   title-en: [],
-  authors-ja: [著者],
+  authors: [著者],
   authors-en: [],
   abstract: none,
   keywords: (),
@@ -18,9 +18,9 @@
 ) = {
   show: jaconf.with(
     // 基本 Basic
-    title-ja: title-ja,
+    tilte: tilte,
     title-en: title-en,
-    authors-ja: authors-ja,
+    authors: authors,
     authors-en: authors-en,
     abstract: abstract,
     keywords: keywords,

--- a/main-templates.typ
+++ b/main-templates.typ
@@ -2,17 +2,17 @@
 // Copyright 2024, 2025 Shunsuke Kimura
 
 // Select the Template
-#import "libs/mscs/lib.typ": mscs as temp, definition, lemma, theorem, corollary, proof, appendix, conference-name
-// #import "libs/rengo/lib.typ": rengo as temp, definition, lemma, theorem, corollary, proof, appendix, conference-name
+// #import "libs/mscs/lib.typ": mscs as temp, definition, lemma, theorem, corollary, proof, appendix, conference-name
+#import "libs/rengo/lib.typ": rengo as temp, definition, lemma, theorem, corollary, proof, appendix, conference-name
 // #import "libs/rsj-conf/lib.typ": rsj-conf as temp, definition, lemma, theorem, corollary, proof, appendix, conference-name
 // #import "libs/sci/lib.typ": sci as temp, definition, lemma, theorem, corollary, proof, appendix, conference-name
 
 // デフォルト値でよい引数は省略可能
 #show: temp.with(
   // 基本 Basic
-  title-ja: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ],
+  tilte: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ],
   title-en: [How to Write a Conference Paper in Japanese],
-  authors-ja: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
+  authors: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
   authors-en: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),
@@ -196,9 +196,9 @@ main.typ の文頭にある以下のコードを解説します。
 // #import "libs/rsj-conf/lib.typ": rsj-conf as temp, definition, lemma, theorem, corollary, proof, appendix
 
 #show: temp.with(
-  title-ja: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ],
+  tilte: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ],
   title-en: [How to Write a Conference Paper in Japanese],
-  authors-ja: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
+  authors: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
   authors-en: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),

--- a/main.typ
+++ b/main.typ
@@ -7,9 +7,9 @@
 // デフォルト値でよい引数は省略可能
 #show: temp.with(
   // 基本 Basic
-  title-ja: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ],
+  title: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ],
   title-en: [How to Write a Conference Paper in Japanese],
-  authors-ja: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
+  authors: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
   authors-en: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),
@@ -34,9 +34,9 @@
   heading-bibliography: [参　考　文　献],
   heading-appendix: [付　録],
   // フォントサイズ Font size
-  font-size-title-ja: 16pt,
+  font-size-title: 16pt,
   font-size-title-en: 12pt,
-  font-size-authors-ja: 12pt,
+  font-size-authors: 12pt,
   font-size-authors-en: 12pt,
   font-size-abstract: 10pt,
   font-size-heading: 11pt,
@@ -226,9 +226,9 @@ main.typ の文頭にある以下のコードを解説します。
 // #import "libs/rsj-conf/lib.typ": rsj-conf as temp, definition, lemma, theorem, corollary, proof, appendix
 
 #show: temp.with(
-  title-ja: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ],
+  tilte: [Typst を使った国内学会論文の書き方 \ - 国内学会予稿集に似せたフォーマットの作成 - ],
   title-en: [How to Write a Conference Paper in Japanese],
-  authors-ja: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
+  authors: [◯ 著者姓1 著者名1、著者姓2 著者名2(○○○大学)、著者姓3 著者名3 (□□□株式会社)],
   authors-en: [\*A. First, B. Second (○○○ Univ.), and C. Third (□□□ Corp.)],
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),


### PR DESCRIPTION
`set documnet`で`title`を設定するときに、必ずしもtitleが日本語であるとは限らない。
この理由から`title-ja`を`title`に、これに合わせる形で`authors-ja`も`authors`に変更した。

https://github.com/kimushun1101/typst-jp-conf-template/blob/1a481af27c20ea98ea57e3c0b27667cff6b79d40/jaconf/lib.typ#L69