### PR TITLE
Fix: font-size-bibliography

### DIFF
--- a/jaconf/lib.typ
+++ b/jaconf/lib.typ
@@ -180,7 +180,7 @@
 
   // Configure Bibliography.
   set bibliography(title: text(size: font-size-heading, heading-bibliography), style: bibliography-style)
-  show bibliography: set text(9pt, font: font-main, lang: "en")
+  show bibliography: set text(font-size-bibliography, lang: "en")
   show bibliography: it => {
     show regex("[0-9a-zA-Z]"): set text(font: font-latin)
     it


### PR DESCRIPTION
`font-size-bibliography`が有効でなかったため修正