### PR TITLE
Add/front matter params

### DIFF
--- a/jaconf/README.md
+++ b/jaconf/README.md
@@ -92,15 +92,16 @@ This is a template for **academic conference papers in Japanese**.
   spacing-heading: 1.2em,
   bibliography-style: "sice.csl",  // "sice.csl", "rsj.csl", "ieee", etc.
   abstract-language: "en",  // "ja" or "en"
+  keywords-language: "en",  // "ja" or "en"
   front-matter-spacing: 1.5em,
   front-matter-margin: 2.0em,
   // 見出し Headings
   heading-abstract: [*Abstract--*],
-  heading-keywords: [*Key Words*: ],
+  heading-keywords: [*Keywords*: ],
   heading-bibliography: [参　考　文　献],
   heading-appendix: [付　録],
   // フォントサイズ Font size
-  font-size-tilte: 16pt,
+  font-size-title: 16pt,
   font-size-title-en: 12pt,
   font-size-authors: 12pt,
   font-size-authors-en: 12pt,

--- a/jaconf/README.md
+++ b/jaconf/README.md
@@ -40,6 +40,7 @@ This is a template for **academic conference papers in Japanese**.
   - `spacing-heading`: 見出しと本文の空き。
   - `bibliography-style`: 参考文献リストの体裁。
   - `abstract-language`: アブストラクトの言語。これによってアブストラクトのフォントが決まります。
+  - `keywords-language`: キーワードリストの言語。これによってキーワードのフォントが決まります。
   - `front-matter-spacing`: 前付けのスペース
   - `front-matter-margin`: 前付けと本文とのマージン
 - 見出し　Headings

--- a/jaconf/README.md
+++ b/jaconf/README.md
@@ -40,6 +40,8 @@ This is a template for **academic conference papers in Japanese**.
   - `spacing-heading`: 見出しと本文の空き。
   - `bibliography-style`: 参考文献リストの体裁。
   - `abstract-language`: アブストラクトの言語。これによってアブストラクトのフォントが決まります。
+  - `front-matter-spacing`: 前付けのスペース
+  - `front-matter-margin`: 前付けと本文とのマージン
 - 見出し　Headings
   - `heading-abstract`: アブストラクトの見出し
   - `heading-keywords`: キーワードの見出し
@@ -90,6 +92,8 @@ This is a template for **academic conference papers in Japanese**.
   spacing-heading: 1.2em,
   bibliography-style: "sice.csl",  // "sice.csl", "rsj.csl", "ieee", etc.
   abstract-language: "en",  // "ja" or "en"
+  front-matter-spacing: 1.5em,
+  front-matter-margin: 2.0em,
   // 見出し Headings
   heading-abstract: [*Abstract--*],
   heading-keywords: [*Key Words*: ],
@@ -101,7 +105,7 @@ This is a template for **academic conference papers in Japanese**.
   font-size-authors: 12pt,
   font-size-authors-en: 12pt,
   font-size-abstract: 10pt,
-  font-size-heading: 11pt,
+  font-size-heading: 12pt,
   font-size-main: 10pt,
   font-size-bibliography: 9pt,
   // 補足語 Supplement

--- a/jaconf/lib.typ
+++ b/jaconf/lib.typ
@@ -13,10 +13,10 @@
 
 #let jaconf(
   // 基本 Basic
-  title: [日本語タイトル],
-  title-en: [],
+  title: [タイトル],
+  title-en: [Title in English],
   authors: [著者],
-  authors-en: [],
+  authors-en: [Authors in English],
   abstract: none,
   keywords: (),
   // フォント名 Font family
@@ -32,6 +32,7 @@
   spacing-heading: 1.2em,
   bibliography-style: "sice.csl",  // "rsj-conf.csl", "rengo.csl", "sci.csl", "ieee"
   abstract-language: "en",  // "ja" or "en"
+  keywords-language: "en",  // "ja" or "en"
   front-matter-spacing: 1.5em,
   front-matter-margin: 2.0em,
   // 見出し Headings
@@ -153,27 +154,32 @@
   v(front-matter-spacing, weak: true)
 
   // Display abstract and index terms.
-  if abstract != none {
-    grid(
-      columns: (0.7cm, 1fr, 0.7cm),
-      [],
-      {
+  grid(
+    columns: (0.7cm, 1fr, 0.7cm),
+    [],
+    {
+      set par(first-line-indent: 0em)
+      if abstract != none {
         set text(
           font-size-abstract,
           font: if abstract-language == "ja" { font-main }
             else { font-latin }
         )
-        set par(first-line-indent: 0em)
-        [
-          #heading-abstract #h(0.5em) #remove-cjk-break-space(abstract)
-        ]
-        if keywords != () {
-          [#v(1em) #heading-keywords #h(0.5em) #keywords.join(", ")]
-        }
-      },
-      []
-    )
-  }
+        [#heading-abstract #h(0.5em) #remove-cjk-break-space(abstract)]
+      }
+      v(1em, weak: true)
+      if keywords != () {
+        set text(
+          font-size-abstract,
+          font: if keywords-language == "ja" { font-main }
+            else { font-latin }
+        )
+        [#heading-keywords #h(0.5em) #keywords.join(", ")]
+      }
+    },
+    []
+  )
+
   v(front-matter-margin)
 
   // Start two column mode and configure paragraph properties.

--- a/jaconf/lib.typ
+++ b/jaconf/lib.typ
@@ -125,9 +125,8 @@
   // Configure headings.
   set heading(numbering: numbering-headings)
   show heading: set block(spacing: spacing-heading)
-  show heading.where(level: 1): set text( size: font-size-heading, font: font-heading, weight: "bold", spacing: 100%)
-  show heading.where(level: 2): set text( size: font-size-main, font: font-heading, weight: "bold")
-  show heading.where(level: 3): set text( size: font-size-main, font: font-heading, weight: "bold")
+  show heading: set text( size: font-size-main, font: font-heading, weight: "bold")
+  show heading.where(level: 1): set text( size: font-size-heading, spacing: 100%)
 
   // Configure figures.
   show figure.where(kind: table): set figure(placement: top, supplement: supplement-table)

--- a/jaconf/lib.typ
+++ b/jaconf/lib.typ
@@ -25,12 +25,12 @@
   font-latin: "New Computer Modern",
   font-math: "New Computer Modern Math",
   // 外観 Appearance
+  paper-margin: (top: 20mm, bottom: 27mm, left: 20mm, right: 20mm),
   paper-columns: 2,  // 1: single column, 2: double column
   page-number: none,  // e.g. "1/1"
-  paper-margin: (top: 20mm, bottom: 27mm, left: 20mm, right: 20mm),
   column-gutter: 4%+0pt,
   spacing-heading: 1.2em,
-  bibliography-style: "sice.csl",  // "rsj-conf.csl", "rengo.csl", "sci.csl", "ieee"
+  bibliography-style: "sice.csl",  // "sice.csl", "rsj.csl", "ieee", etc.
   abstract-language: "en",  // "ja" or "en"
   keywords-language: "en",  // "ja" or "en"
   front-matter-spacing: 1.5em,
@@ -57,7 +57,7 @@
   numbering-headings: "1.1",
   numbering-equation: "(1)",
   numbering-appendix: "A.1",  // #show: appendix.with(numbering-appendix: "A.1") の呼び出しにも同じ引数を与えてください。
-  // main text
+  // 本文
   body
 ) = {
   // Set metadata.

--- a/jaconf/lib.typ
+++ b/jaconf/lib.typ
@@ -125,8 +125,8 @@
   // Configure headings.
   set heading(numbering: numbering-headings)
   show heading: set block(spacing: spacing-heading)
-  show heading: set text( size: font-size-main, font: font-heading, weight: "bold")
-  show heading.where(level: 1): set text( size: font-size-heading, spacing: 100%)
+  show heading: set text(size: font-size-main, font: font-heading, weight: "bold")
+  show heading.where(level: 1): set text(size: font-size-heading)
 
   // Configure figures.
   show figure.where(kind: table): set figure(placement: top, supplement: supplement-table)

--- a/jaconf/lib.typ
+++ b/jaconf/lib.typ
@@ -32,6 +32,8 @@
   spacing-heading: 1.2em,
   bibliography-style: "sice.csl",  // "rsj-conf.csl", "rengo.csl", "sci.csl", "ieee"
   abstract-language: "en",  // "ja" or "en"
+  front-matter-spacing: 1.5em,
+  front-matter-margin: 2.0em,
   // 見出し Headings
   heading-abstract: [*Abstract--*],
   heading-keywords: [*Keywords*: ],
@@ -136,19 +138,19 @@
 
   // Display the paper's title.
   align(center, text(font-size-title, title, weight: "bold", font: font-heading))
-  v(18pt, weak: true)
+  v(front-matter-spacing, weak: true)
 
   // Display the authors list.
   align(center, text(font-size-authors, authors, font: font-main))
-  v(1.5em, weak: true)
+  v(front-matter-spacing, weak: true)
 
   // Display the paper's title in English.
   align(center, text(font-size-title-en, title-en, weight: "bold", font: font-latin))
-  v(1.5em, weak: true)
+  v(front-matter-spacing, weak: true)
 
   // Display the authors list in English.
   align(center, text(font-size-authors-en, authors-en, font: font-latin))
-  v(1.5em, weak: true)
+  v(front-matter-spacing, weak: true)
 
   // Display abstract and index terms.
   if abstract != none {
@@ -171,8 +173,8 @@
       },
       []
     )
-    v(1em, weak: false)
   }
+  v(front-matter-margin)
 
   // Start two column mode and configure paragraph properties.
   show: columns.with(paper-columns, gutter: column-gutter)

--- a/jaconf/template/main.typ
+++ b/jaconf/template/main.typ
@@ -25,15 +25,16 @@
   spacing-heading: 1.2em,
   bibliography-style: "sice.csl",  // "sice.csl", "rsj.csl", "ieee", etc.
   abstract-language: "en",  // "ja" or "en"
+  keywords-language: "en",  // "ja" or "en"
   front-matter-spacing: 1.5em,
   front-matter-margin: 2.0em,
   // 見出し Headings
   heading-abstract: [*Abstract--*],
-  heading-keywords: [*Key Words*: ],
+  heading-keywords: [*Keywords*: ],
   heading-bibliography: [参　考　文　献],
   heading-appendix: [付　録],
   // フォントサイズ Font size
-  font-size-tilte: 16pt,
+  font-size-title: 16pt,
   font-size-title-en: 12pt,
   font-size-authors: 12pt,
   font-size-authors-en: 12pt,

--- a/jaconf/template/main.typ
+++ b/jaconf/template/main.typ
@@ -25,6 +25,8 @@
   spacing-heading: 1.2em,
   bibliography-style: "sice.csl",  // "sice.csl", "rsj.csl", "ieee", etc.
   abstract-language: "en",  // "ja" or "en"
+  front-matter-spacing: 1.5em,
+  front-matter-margin: 2.0em,
   // 見出し Headings
   heading-abstract: [*Abstract--*],
   heading-keywords: [*Key Words*: ],
@@ -36,7 +38,7 @@
   font-size-authors: 12pt,
   font-size-authors-en: 12pt,
   font-size-abstract: 10pt,
-  font-size-heading: 11pt,
+  font-size-heading: 12pt,
   font-size-main: 10pt,
   font-size-bibliography: 9pt,
   // 補足語 Supplement

--- a/main.typ
+++ b/main.typ
@@ -14,8 +14,6 @@
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),
   // フォント名 Font family
-  // font-gothic: "Noto Sans CJK JP",  // outdated
-  // font-mincho: "Noto Serif CJK JP",  // outdated
   font-heading: "Noto Sans CJK JP",
   font-main: "Noto Serif CJK JP",
   font-latin: "New Computer Modern",
@@ -28,6 +26,8 @@
   spacing-heading: 1.2em,
   bibliography-style: "sice.csl",  // "sice.csl", "rsj.csl", "ieee", etc.
   abstract-language: "en",  // "ja" or "en"
+  front-matter-spacing: 1.5em,
+  front-matter-margin: 2.0em,
   // 見出し Headings
   heading-abstract: [*Abstract--*],
   heading-keywords: [*Key Words*: ],
@@ -39,7 +39,7 @@
   font-size-authors: 12pt,
   font-size-authors-en: 12pt,
   font-size-abstract: 10pt,
-  font-size-heading: 11pt,
+  font-size-heading: 12pt,
   font-size-main: 10pt,
   font-size-bibliography: 9pt,
   // 補足語 Supplement

--- a/main.typ
+++ b/main.typ
@@ -14,23 +14,24 @@
   abstract: [#lorem(80)],
   keywords: ([Typst], [conference paper writing], [manuscript format]),
   // フォント名 Font family
-  font-heading: "Noto Sans CJK JP",
-  font-main: "Noto Serif CJK JP",
+  font-heading: "Noto Sans CJK JP",  // サンセリフ体、ゴシック体などの指定を推奨
+  font-main: "Noto Serif CJK JP",  // セリフ体、明朝体などの指定を推奨
   font-latin: "New Computer Modern",
   font-math: "New Computer Modern Math",
   // 外観 Appearance
+  paper-margin: (top: 20mm, bottom: 27mm, left: 20mm, right: 20mm),
   paper-columns: 2,  // 1: single column, 2: double column
   page-number: none,  // e.g. "1/1"
-  paper-margin: (top: 20mm, bottom: 27mm, left: 20mm, right: 20mm),
   column-gutter: 4%+0pt,
   spacing-heading: 1.2em,
   bibliography-style: "sice.csl",  // "sice.csl", "rsj.csl", "ieee", etc.
   abstract-language: "en",  // "ja" or "en"
+  keywords-language: "en",  // "ja" or "en"
   front-matter-spacing: 1.5em,
   front-matter-margin: 2.0em,
   // 見出し Headings
   heading-abstract: [*Abstract--*],
-  heading-keywords: [*Key Words*: ],
+  heading-keywords: [*Keywords*: ],
   heading-bibliography: [参　考　文　献],
   heading-appendix: [付　録],
   // フォントサイズ Font size


### PR DESCRIPTION
以下のパラメーターを追加しました。

- `front-matter-spacing`: 前付けのスペース
- `front-matter-margin`: 前付けと本文とのマージン
- `keywords-language`: キーワードリストの言語。

`keywords`が`none`のときの対応を追加しました。