### PR TITLE
Add: SICE SI template

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "aisuitcase",
         "caamp",
+        "codly",
         "ctheorems",
         "Hayagriva",
         "Hiragino",
@@ -24,6 +25,7 @@
         "titlefmt",
         "tlsv",
         "Typst",
+        "unbreak",
         "winget",
         "Zenn"
     ]

--- a/libs/sice-si/lib.typ
+++ b/libs/sice-si/lib.typ
@@ -1,0 +1,65 @@
+// MIT No Attribution
+// Copyright 2024, 2025 Shunsuke Kimura
+
+#let conference-name = "SICE SI部門講演会"
+#import "@preview/jaconf:0.5.1": jaconf, definition, lemma, theorem, corollary, proof, appendix
+
+#let sice-si(
+  title: [日本語タイトル],
+  title-en: [],
+  authors: [著者],
+  authors-en: [],
+  abstract: none,
+  keywords: (),
+  font-gothic: "Noto Sans CJK JP",
+  font-mincho: "Noto Serif CJK JP",
+  font-latin: "New Computer Modern",
+  body
+) = {
+  show: jaconf.with(
+    // 基本 Basic
+    title: title,
+    title-en: title-en,
+    authors: authors,
+    authors-en: authors-en,
+    abstract: abstract,
+    keywords: keywords,
+    // フォント名 Font family
+    font-heading: font-gothic,
+    font-main: font-mincho,
+    font-latin: font-latin,
+    // 外観 Appearance
+    paper-margin: (top: 20mm, bottom: 27mm, x: 15mm),
+    paper-columns: 2,  // 1: single column, 2: double column
+    page-number: none,  // e.g. "1/1"
+    column-gutter: 4%+0pt,
+    spacing-heading: 0.5em,
+    front-matter-order: ("title", "authors", "title-en", "authors-en", "abstract", "keywords"),  // 独自コンテンツの追加も可能
+    front-matter-spacing: 1.5em,
+    front-matter-margin: 2.0em,
+    abstract-language: "en",  // "ja" or "en"
+    bibliography-style: bytes(read("sice-si.csl")),  // "sice.csl", "rsj.csl", "ieee", etc.
+    // 見出し Headings
+    heading-abstract: [Abstract:],
+    heading-bibliography: [参考文献],
+    heading-appendix: [付録],
+    // フォントサイズ Font size
+    font-size-title: 16pt,
+    font-size-title-en: 12pt,
+    font-size-authors: 12pt,
+    font-size-authors-en: 12pt,
+    font-size-abstract: 9pt,
+    font-size-heading: 12pt,
+    font-size-main: 10pt,
+    font-size-bibliography: 9pt,
+    // 補足語 Supplement
+    supplement-image: [Fig.],
+    supplement-table: [Table],
+    supplement-separator: [　],
+    // 番号付け Numbering
+    numbering-headings: "1.",
+    numbering-equation: "(1)",
+    numbering-appendix: "A.1",  // #show: appendix.with(numbering-appendix: "A.1") の呼び出しにも同じ引数を与えてください。
+  )
+  body
+}

--- a/libs/sice-si/sice-si.csl
+++ b/libs/sice-si/sice-si.csl
@@ -1,0 +1,211 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="ja-JP">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>The Society of Instrument and Control Engineers</title>
+    <title-short>SICE</title-short>
+    <id>https://github.com/kimushun1101/typst-jp-conf-template/blob/main/libs/mscs/sice.csl</id>
+    <link href="https://www.sice.or.jp/wp-content/uploads/file/trans/tebiki.pdf" rel="documentation"/>
+    <author>
+      <name>Shunsuke Kimura</name>
+      <email>kimushun1101@gmail.com</email>
+      <uri>https://github.com/kimushun1101</uri>
+    </author>
+    <category citation-format="numeric"/>
+    <summary>計測自動制御学会の参考文献引用フォーマット</summary>
+    <updated>2024-03-30T14:26:30+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en"> <!-- なぜかenしか効かない -->
+    <terms>
+      <term name="page-range-delimiter">/</term>
+    </terms>
+  </locale>
+  <macro name="edition">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" text-case="capitalize-first" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <date variable="issued" prefix="(" suffix=")">
+      <date-part name="year" form="long"/>
+    </date>
+  </macro>
+  <macro name="author">
+    <choose>
+      <if match="any" variable="language">
+        <names variable="author">
+          <name form="long" delimiter=", "/>
+          <label form="short" prefix=", "/>
+          <substitute>
+            <names variable="editor"/>
+          </substitute>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name initialize-with=". " delimiter=", " and="text"/>
+          <label form="short" prefix=", "/>
+          <substitute>
+            <names variable="editor"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name initialize-with=". " delimiter=", " and="text"/>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="locators">
+    <group delimiter="-">
+      <text macro="edition"/>
+      <group>
+        <number variable="volume" form="numeric" font-weight="bold"/>
+      </group>
+      <group delimiter=" ">
+        <number variable="issue" form="numeric"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture song" match="any">
+        <text variable="title"/>
+      </if>
+      <else>
+        <text variable="title"/>
+        <!-- <text variable="title" quotes="true"/> -->
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if type="paper-conference">
+        <choose>
+          <if variable="container-title">
+            <group delimiter=", ">
+              <text variable="container-title"/>
+              <text variable="event-place"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <text variable="event"/>
+              <text variable="event-place"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="webpage" match="any">
+        <text variable="URL" prefix=" URL: " suffix=" "/>
+        <date variable="accessed" prefix="Accessed on ">
+          <date-part name="year" form="long" suffix="."/>
+          <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+          <date-part name="day" suffix="."/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <macro name="page">
+    <text variable="page"/>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="" suffix="" delimiter=", "  vertical-align="sup">
+      <text variable="citation-number" vertical-align="sup"  suffix=")" />
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" second-field-align="flush">
+    <layout suffix=".">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="author" suffix=", "/>
+      <choose>
+        <if type="article-journal">
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text variable="container-title" font-style="italic" form="short"/>
+            <text macro="locators"/>
+            <text macro="page"/>
+          </group>
+          <text macro="issued" prefix=" "/>
+        </if>
+        <else-if type="paper-conference">
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text macro="event"/>
+            <text macro="locators"/>
+            <text macro="page"/>
+          </group>
+          <text macro="issued" prefix=" "/>
+        </else-if>
+        <else-if type="book" match="any">
+          <group delimiter=", " suffix=". ">
+            <text macro="title"/>
+            <text macro="locators"/>
+          </group>
+          <text macro="publisher"/>
+          <text macro="issued" prefix=" "/>
+        </else-if>
+        <else-if type="webpage">
+          <group delimiter=", " suffix=". ">
+            <text macro="title"/>
+            <text macro="publisher"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <text macro="title" suffix=", "/>
+          <text variable="number"/>
+          <text macro="issued"/>
+        </else-if>
+        <else-if type="article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text variable="container-title" font-style="italic"/>
+            <text macro="locators"/>
+            <text macro="publisher"/>
+            <text macro="page"/>
+            <text macro="issued"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text variable="container-title"/>
+            <text macro="locators"/>
+            <text macro="publisher"/>
+            <text macro="page"/>
+            <text macro="issued"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/main-templates.typ
+++ b/main-templates.typ
@@ -6,6 +6,7 @@
 // #import "libs/rengo/lib.typ": rengo as temp, definition, lemma, theorem, corollary, proof, appendix, conference-name
 // #import "libs/rsj-conf/lib.typ": rsj-conf as temp, definition, lemma, theorem, corollary, proof, appendix, conference-name
 // #import "libs/sci/lib.typ": sci as temp, definition, lemma, theorem, corollary, proof, appendix, conference-name
+// #import "libs/sice-si/lib.typ": sice-si as temp, definition, lemma, theorem, corollary, proof, appendix, conference-name
 
 // デフォルト値でよい引数は省略可能
 #show: temp.with(


### PR DESCRIPTION
SICE SIのテンプレートを追加しました。
https://sice-si.org/si2025/paper.php

現在は、セクション名が「1.」で始まるのに対して、サブセクションが「1.1」とピリオドなしで始まってしまう部分だけ対応できていませんが、時間がかかりそうなためここらで一旦マージしてしまいます。