### PR TITLE
Update/doc supplement ref eq

### DIFF
--- a/jaconf/README.md
+++ b/jaconf/README.md
@@ -62,7 +62,7 @@ This is a template for **academic conference papers in Japanese**.
   - `supplement-image`: 図タイトルの接頭辞
   - `supplement-table`: 表タイトルの接頭辞
   - `supplement-separator`: 図表の接頭辞とタイトルの区切り文字
-  - `supplement-ref-equation`: 本文中で引用する際に、数式番号につける接頭辞
+  - `supplement-equation-ref`: 本文中で引用する際に、数式番号につける接頭辞
 - 番号付け　Numbering
   - `numbering-headings`: 本文の見出し番号の体裁
   - `numbering-equation`: 式番号の体裁

--- a/jaconf/README.md
+++ b/jaconf/README.md
@@ -117,6 +117,7 @@ This is a template for **academic conference papers in Japanese**.
   supplement-image: [図],
   supplement-table: [表],
   supplement-separator: [: ],
+  supplement-equation-ref: [],  // 式、Eq. など
   // 番号付け Numbering
   numbering-headings: "1.1",
   numbering-equation: "(1)",

--- a/jaconf/README.md
+++ b/jaconf/README.md
@@ -61,7 +61,8 @@ This is a template for **academic conference papers in Japanese**.
 - 補足語　Supplement
   - `supplement-image`: 図タイトルの接頭辞
   - `supplement-table`: 表タイトルの接頭辞
-  - `supplement-separator`: 接頭辞とタイトルの区切り文字
+  - `supplement-separator`: 図表の接頭辞とタイトルの区切り文字
+  - `supplement-ref-equation`: 本文中で引用する際に、数式番号につける接頭辞
 - 番号付け　Numbering
   - `numbering-headings`: 本文の見出し番号の体裁
   - `numbering-equation`: 式番号の体裁

--- a/jaconf/lib.typ
+++ b/jaconf/lib.typ
@@ -54,7 +54,7 @@
   supplement-image: [図],
   supplement-table: [表],
   supplement-separator: [: ],
-  supplement-ref-equation: [],  // 式、Eq. など
+  supplement-equation-ref: [],  // 式、Eq. など
   // 番号付け Numbering
   numbering-headings: "1.1",
   numbering-equation: "(1)",
@@ -97,7 +97,7 @@
     let el = it.element
     if el != none and el.func() == eq {
       let num = numbering(el.numbering, ..counter(eq).at(el.location()))
-      link(el.location(), [#supplement-ref-equation #num])
+      link(el.location(), [#supplement-equation-ref #num])
     }
     // Sections -> n章m節l項.
     // Appendix -> 付録A.

--- a/jaconf/lib.typ
+++ b/jaconf/lib.typ
@@ -53,8 +53,8 @@
   // 補足語 Supplement
   supplement-image: [図],
   supplement-table: [表],
-  supplement-ref-equation: [],  // 式、Eq. など
   supplement-separator: [: ],
+  supplement-ref-equation: [],  // 式、Eq. など
   // 番号付け Numbering
   numbering-headings: "1.1",
   numbering-equation: "(1)",

--- a/jaconf/template/main.typ
+++ b/jaconf/template/main.typ
@@ -47,7 +47,7 @@
   supplement-image: [図],
   supplement-table: [表],
   supplement-separator: [: ],
-  supplement-ref-equation: [],  // 式、Eq. など
+  supplement-equation-ref: [],  // 式、Eq. など
   // 番号付け Numbering
   numbering-headings: "1.1",
   numbering-equation: "(1)",

--- a/jaconf/template/main.typ
+++ b/jaconf/template/main.typ
@@ -47,6 +47,7 @@
   supplement-image: [図],
   supplement-table: [表],
   supplement-separator: [: ],
+  supplement-ref-equation: [],  // 式、Eq. など
   // 番号付け Numbering
   numbering-headings: "1.1",
   numbering-equation: "(1)",

--- a/jaconf/typst.toml
+++ b/jaconf/typst.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/kimushun1101/typst-jp-conf-template"
 authors = [
   "Shunsuke Kimura <https://github.com/kimushun1101>",
   "ささくらり <https://github.com/m-tsuru>",
+  "Tomoya Oku <https://github.com/Tomoya-Oku>",
 ]
 license = "MIT-0"
 description = "Template for Japanese academic conference papers. 日本語の学会論文テンプレート"


### PR DESCRIPTION
- #34 で追加した機能をREADMEとテンプレート用mainに追加いたしました。
- こちらから提案しておきながら申し訳ないのですが、変数名を`supplement-ref-equation`から`supplement-equation-ref`に変更しました。LaTeXでは`eqref`と引用するため、それに合わせたものになります。既存パラメータとして`numbering-equation`があるため、equationは省略しませんでした。
- Typst Universeへの登録はこれの後行う予定です。typst.tomlに @Tomoya-Oku さんのお名前を記載させていただきました。Typst UniverseのAuthorsに掲載されますがよろしいでしょうか？ https://typst.app/universe/package/jaconf