### PR TITLE
Fix: front-matter-order と keywords の単一要素・none 渡しに関する不具合を修正

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -140,6 +140,12 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: supplement-separator)
 
   // Title and Authors
+  // 単一要素を文字列で渡された場合 (例: front-matter-order: ("abstract")) は配列に変換する
+  let front-matter-order = if type(front-matter-order) == str {
+    (front-matter-order,)
+  } else {
+    front-matter-order
+  }
   for item in front-matter-order {
     if item == "title" and title != [] {
       // Display the paper's title.

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -146,6 +146,14 @@
   } else {
     front-matter-order
   }
+  // keywords も同様に正規化する。none の場合は空配列として扱い、後段の join でエラーにならないようにする
+  let keywords = if keywords == none {
+    ()
+  } else if type(keywords) == str {
+    (keywords,)
+  } else {
+    keywords
+  }
   for item in front-matter-order {
     if item == "title" and title != [] {
       // Display the paper's title.

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -146,10 +146,11 @@
   } else {
     front-matter-order
   }
-  // keywords も同様に正規化する。none の場合は空配列として扱い、後段の join でエラーにならないようにする
+  // keywords を配列に正規化する。none は空配列、配列以外 (str や content) は単一要素配列として扱い、
+  // 後段の join でエラーにならないようにする。content の場合 ([aaa] や ([aaa]) のような渡し方) も吸収する。
   let keywords = if keywords == none {
     ()
-  } else if type(keywords) == str {
+  } else if type(keywords) != array {
     (keywords,)
   } else {
     keywords


### PR DESCRIPTION
## 概要
配列を期待するパラメータに単一要素や `none` が渡されたときに、Typst の仕様上の落とし穴で意図しない挙動・エラーになる問題をまとめて修正します。

## 背景
Typst では、単一要素配列を作るには末尾カンマ `("title",)` が必要で、`("title")` は単に括弧で囲まれた式 (= 文字列) として扱われます ([公式ドキュメント](https://typst.app/docs/reference/foundations/array/))。これは `(1 + 2) * 3` のような算術式と区別するための仕様で、利用者が末尾カンマを付け忘れることでハマりがちなポイントです。テンプレート側でこの差を吸収します。

## 修正内容
1. **`front-matter-order`**: 文字列が渡された場合は単一要素配列に変換する。これまで `for` ループが文字列の各文字を反復してしまい、前付け表示が崩れていました。
2. **`keywords`**: 配列以外の型 (str や content) が渡された場合は単一要素配列に変換する。さらに `none` を渡した場合に `.join(\", \")` でエラーになっていたため、空配列として扱うように正規化する。
