### PR TITLE
Update: cjk-unbreak を 0.2.3 にアップグレード

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -1,7 +1,7 @@
 // import third-party packages
 #import "@preview/codly:1.3.0": codly-init
 #import "@preview/ctheorems:1.1.3": thmplain, thmproof, thmrules
-#import "@preview/cjk-unbreak:0.2.2": remove-cjk-break-space
+#import "@preview/cjk-unbreak:0.2.3": remove-cjk-break-space
 
 // Theorem environments
 #let thmja = thmplain.with(base: {}, separator: [#h(0.5em)], titlefmt: strong, inset: (top: 0em, left: 0em))


### PR DESCRIPTION
## 概要
`@preview/cjk-unbreak` を 0.2.2 → 0.2.3 に更新します。

## 0.2.3 の変更点
- `rotate` 関数およびオプショナルな位置引数 (Positional / not Required) のハンドリング修正
- `columns` への対応追加

参考: https://github.com/KZNS/cjk-unbreak/releases/tag/v0.2.3

## 動作確認
- `tests/test-compile-doc.typ` を 0.2.2 / 0.2.3 双方でコンパイルし、PNG 出力 (全 6 ページ) がバイト単位で一致することを確認
- API (`remove-cjk-break-space`) に変更はなく、既存の呼び出し箇所への影響なし

## チェックリスト
- [x] `tests/test-compile-doc.typ` のコンパイルが成功する
- [x] 0.2.2 と 0.2.3 で既存テストの出力に差分がない