### PR TITLE
Update: バージョン依存の画像形式の記述を削除し placement の説明を追加

### DIFF
--- a/examples/example.typ
+++ b/examples/example.typ
@@ -254,8 +254,6 @@ $ u = K_P e + K_I integral_0^t e d t $ <eq:PI-controller>
 ただし、$K_P$ と $K_I$ はそれぞれ比例ゲイン、積分ゲインとする。
 
 == 図と表
-本稿を執筆時のバージョン Typst 0.13.1 では、PNG, JPEG, GIF, SVG の形式のイメージデータを挿入することができます。
-PDFの挿入は muchpdfパッケージ(https://typst.app/universe/package/muchpdf)を使用すれば可能ですが、ここでは説明しません。
 SVGとPNGの表示例としては以下の通りです。
 ```typ
   #figure(

--- a/template/main.typ
+++ b/template/main.typ
@@ -123,6 +123,7 @@ $ u = K_P e + K_I integral_0^t e d t $ <eq:PI-controller>
   // image("figs/quadratic.svg", width: 90%),
   caption: [$x^2$ のグラフ],
 ) <fig:quadratic>
+ここでplacementは、紙面の上(top)に寄せるか下(bottom)に寄せるかを決められます。言及している文章に近い方や見栄えが良い方に調整してください。
 
 === 定理環境 <sec:theorem>
 以下はtheorem環境の使用例です。

--- a/tests/test-compile-doc.typ
+++ b/tests/test-compile-doc.typ
@@ -290,8 +290,6 @@ $ u = K_P e + K_I integral_0^t e d t $ <eq:PI-controller>
 ただし、$K_P$と$K_I$はそれぞれ比例ゲイン、積分ゲインとする。
 
 == 図と表
-本稿を執筆時のバージョンTypst 0.13.1では、PNG, JPEG, GIF, SVG の形式のイメージデータを挿入することができます。
-PDFの挿入はmuchpdfパッケージ(https://typst.app/universe/package/muchpdf)を使用すれば可能ですが、ここでは説明しません。
 SVGとPNGの表示例としては以下の通りです。
 ```typ
   #figure(


### PR DESCRIPTION
- `examples/example.typ` および `tests/test-compile-doc.typ` にあった「Typst 0.13.1 では PNG, JPEG, GIF, SVG が挿入できる」「PDFの挿入は muchpdf パッケージを使う」というバージョン依存の記述を削除しました。Typst 0.14.0 以降は image 関数で PDF や WebP も直接扱えるようになっており、また将来的なバージョンアップでも記述を維持しやすいよう、形式を列挙しない方針に変更しています。
- `template/main.typ` に placement の説明を追加しました。