### PR TITLE
Fix: フロントマター引数の none/空 渡しによる挙動を整理

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -139,79 +139,86 @@
   show figure.where(kind: image): set figure(placement: top, supplement: supplement-image)
   show figure.where(kind: image): set figure.caption(position: bottom, separator: supplement-separator)
 
-  // Title and Authors
   // 単一要素を文字列で渡された場合 (例: front-matter-order: ("abstract")) は配列に変換する
   let front-matter-order = if type(front-matter-order) == str {
     (front-matter-order,)
   } else {
     front-matter-order
   }
-  // keywords を配列に正規化する。none は空配列、配列以外 (str や content) は単一要素配列として扱い、
-  // 後段の join でエラーにならないようにする。content の場合 ([aaa] や ([aaa]) のような渡し方) も吸収する。
+  // keywords を配列に正規化する。配列以外 (str や content) は単一要素配列として扱い、後段の join でエラーにならないようにする。
+  // none はそのまま none として保持し、ブロックごと非表示の判定に使う。
   let keywords = if keywords == none {
-    ()
+    none
   } else if type(keywords) != array {
     (keywords,)
   } else {
     keywords
   }
   for item in front-matter-order {
-    if item == "title" and title != [] {
-      // Display the paper's title.
-      align(center, text(font-size-title, title, weight: "bold", font: font-heading))
-      v(front-matter-spacing, weak: true)
-    } else if item == "authors" and authors != [] {
-      // Display the authors list.
-      align(center, text(font-size-authors, authors, font: font-main))
-      v(front-matter-spacing, weak: true)
-    } else if item == "title-en" and title-en != [] {
-      // Display the paper's title in English.
-      align(center, text(font-size-title-en, title-en, weight: "bold", font: font-latin))
-      v(front-matter-spacing, weak: true)
-    } else if item == "authors-en" and authors-en != [] {
-      // Display the authors list in English.
-      align(center, text(font-size-authors-en, authors-en, font: font-latin))
-      v(front-matter-spacing, weak: true)
-    } else if item == "abstract" and abstract != none {
-      // Display abstract.
-      v(abstract-margin.top, weak: true)
-      grid(
-        columns: (abstract-margin.left, 1fr, abstract-margin.right),
-        [],
-        {
-          set par(first-line-indent: 0em)
-          if abstract != none {
+    if item == "title" {
+      if title != none and title != [] {
+        // Display the paper's title.
+        align(center, text(font-size-title, title, weight: "bold", font: font-heading))
+        v(front-matter-spacing, weak: true)
+      }
+    } else if item == "authors" {
+      if authors != none and authors != [] {
+        // Display the authors list.
+        align(center, text(font-size-authors, authors, font: font-main))
+        v(front-matter-spacing, weak: true)
+      }
+    } else if item == "title-en" {
+      if title-en != none and title-en != [] {
+        // Display the paper's title in English.
+        align(center, text(font-size-title-en, title-en, weight: "bold", font: font-latin))
+        v(front-matter-spacing, weak: true)
+      }
+    } else if item == "authors-en" {
+      if authors-en != none and authors-en != [] {
+        // Display the authors list in English.
+        align(center, text(font-size-authors-en, authors-en, font: font-latin))
+        v(front-matter-spacing, weak: true)
+      }
+    } else if item == "abstract" {
+      if abstract != none {
+        // Display abstract.
+        v(abstract-margin.top, weak: true)
+        grid(
+          columns: (abstract-margin.left, 1fr, abstract-margin.right),
+          [],
+          {
+            set par(first-line-indent: 0em)
             set text(
               font-size-abstract,
               font: if abstract-language == "ja" { font-main }
                 else { font-latin }
             )
             [#heading-abstract #h(0.5em) #remove-cjk-break-space(abstract)]
-          }
-        },
-        []
-      )
-      v(abstract-margin.bottom, weak: true)
-    } else if item == "keywords" and keywords != () {
-      // Display index terms as keywords.
-      v(keywords-margin.top, weak: true)
-      grid(
-        columns: (keywords-margin.left, 1fr, keywords-margin.right),
-        [],
-        {
-          set par(first-line-indent: 0em)
-          if keywords != () {
+          },
+          []
+        )
+        v(abstract-margin.bottom, weak: true)
+      }
+    } else if item == "keywords" {
+      if keywords != none {
+        // Display index terms as keywords.
+        v(keywords-margin.top, weak: true)
+        grid(
+          columns: (keywords-margin.left, 1fr, keywords-margin.right),
+          [],
+          {
+            set par(first-line-indent: 0em)
             set text(
               font-size-abstract,
               font: if keywords-language == "ja" { font-main }
                 else { font-latin }
             )
             [#heading-keywords #h(0.5em) #keywords.join(", ")]
-          }
-        },
-        []
-      )
-      v(keywords-margin.bottom, weak: true)
+          },
+          []
+        )
+        v(keywords-margin.bottom, weak: true)
+      }
     } else {
       item
     }


### PR DESCRIPTION
## 概要
フロントマター (`title`, `title-en`, `authors`, `authors-en`, `abstract`, `keywords`) の各引数に `none` や空コンテンツ (`[]` / `()`) を渡したときの挙動が不揃いだったため整理しました。

## 変更内容
- `for` ループの末尾 `else { item }` のフォールスルーで、引数を `none` にすると `front-matter-order` のキー文字列 (例: `"title"`) がそのまま本文に出力される不具合を修正。
- 外側分岐を `item` の判別、内側で値の空判定を行う構造に整理。
- `keywords` の正規化で `none` を `()` に潰さず `none` のまま保持するよう変更し、ブロック削除と空配列を区別できるようにした。

## 仕様
| フィールド | `none` | `[]` / `()` | 値あり |
|---|---|---|---|
| title / authors / title-en / authors-en | ブロックごと削除 | ブロックごと削除 | 通常表示 |
| abstract | ブロックごと削除 | 見出し語 (`Abstract--`) のみ表示 | 通常表示 |
| keywords | ブロックごと削除 | 見出し語 (`Keywords:`) のみ表示 | 通常表示 |

## 動作確認
- 既存の `tests/test-compile-doc.typ` がそのままコンパイル可能。
- `title: none` / `title-en: []` / `authors: [Author A]` / `abstract: []` / `keywords: ()` の組合せで、abstract と keywords は見出し語のみ、title 系は完全に消えることを確認。