### PR TITLE
Fix: 和文文書で参考文献の欧文著者接続が「と」になる問題を修正

### DIFF
--- a/examples/mscs/sice.csl
+++ b/examples/mscs/sice.csl
@@ -16,8 +16,9 @@
     <updated>2024-03-30T14:26:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="en"> <!-- なぜかenしか効かない -->
+  <locale>
     <terms>
+      <term name="and">and</term>
       <term name="page-range-delimiter">/</term>
     </terms>
   </locale>
@@ -56,7 +57,7 @@
       </if>
       <else>
         <names variable="author">
-          <name initialize-with=". " delimiter=", " and="text"/>
+          <name initialize-with=". " delimiter=", " and="text" delimiter-precedes-last="never"/>
           <label form="short" prefix=", "/>
           <substitute>
             <names variable="editor"/>
@@ -67,7 +68,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name initialize-with=". " delimiter=", " and="text"/>
+      <name initialize-with=". " delimiter=", " and="text" delimiter-precedes-last="never"/>
       <label form="short" prefix=", "/>
     </names>
   </macro>

--- a/examples/rengo/rengo.csl
+++ b/examples/rengo/rengo.csl
@@ -17,6 +17,11 @@
     <updated>2024-07-06T21:04:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale>
+    <terms>
+      <term name="and">and</term>
+    </terms>
+  </locale>
   <locale xml:lang="en">
     <date form="text">
       <date-part name="month" form="short" suffix=" "/>
@@ -40,7 +45,7 @@
       </if>
       <else>
         <names variable="author">
-          <name initialize-with=". " delimiter=", " and="text"/>
+          <name initialize-with=". " delimiter=", " and="text" delimiter-precedes-last="never"/>
           <label form="short" prefix=", "/>
         </names>
       </else>

--- a/examples/rsj-conf/rsj-conf.csl
+++ b/examples/rsj-conf/rsj-conf.csl
@@ -17,6 +17,11 @@
     <updated>2024-03-30T14:26:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale>
+    <terms>
+      <term name="and">and</term>
+    </terms>
+  </locale>
   <macro name="edition">
     <choose>
       <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">

--- a/examples/sci/sci.csl
+++ b/examples/sci/sci.csl
@@ -17,6 +17,11 @@
     <updated>2024-07-06T21:04:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale>
+    <terms>
+      <term name="and">and</term>
+    </terms>
+  </locale>
   <locale xml:lang="en">
     <date form="text">
       <date-part name="month" form="short" suffix=" "/>
@@ -40,7 +45,7 @@
       </if>
       <else>
         <names variable="author">
-          <name initialize-with=". " delimiter=", " and="text"/>
+          <name initialize-with=". " delimiter=", " and="text" delimiter-precedes-last="never"/>
           <label form="short" prefix=", "/>
         </names>
       </else>

--- a/examples/sice-si/sice-si.csl
+++ b/examples/sice-si/sice-si.csl
@@ -16,8 +16,9 @@
     <updated>2024-03-30T14:26:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="en"> <!-- なぜかenしか効かない -->
+  <locale>
     <terms>
+      <term name="and">and</term>
       <term name="page-range-delimiter">/</term>
     </terms>
   </locale>
@@ -56,7 +57,7 @@
       </if>
       <else>
         <names variable="author">
-          <name initialize-with=". " delimiter=", " and="text"/>
+          <name initialize-with=". " delimiter=", " and="text" delimiter-precedes-last="never"/>
           <label form="short" prefix=", "/>
           <substitute>
             <names variable="editor"/>
@@ -67,7 +68,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name initialize-with=". " delimiter=", " and="text"/>
+      <name initialize-with=". " delimiter=", " and="text" delimiter-precedes-last="never"/>
       <label form="short" prefix=", "/>
     </names>
   </macro>

--- a/src/rsj.csl
+++ b/src/rsj.csl
@@ -17,6 +17,11 @@
     <updated>2024-03-30T14:26:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale>
+    <terms>
+      <term name="and">and</term>
+    </terms>
+  </locale>
   <macro name="edition">
     <choose>
       <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">

--- a/src/sice.csl
+++ b/src/sice.csl
@@ -16,8 +16,9 @@
     <updated>2024-03-30T14:26:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="en"> <!-- なぜかenしか効かない -->
+  <locale>
     <terms>
+      <term name="and">and</term>
       <term name="page-range-delimiter">/</term>
     </terms>
   </locale>
@@ -56,7 +57,7 @@
       </if>
       <else>
         <names variable="author">
-          <name initialize-with=". " delimiter=", " and="text"/>
+          <name initialize-with=". " delimiter=", " and="text" delimiter-precedes-last="never"/>
           <label form="short" prefix=", "/>
           <substitute>
             <names variable="editor"/>
@@ -67,7 +68,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name initialize-with=". " delimiter=", " and="text"/>
+      <name initialize-with=". " delimiter=", " and="text" delimiter-precedes-last="never"/>
       <label form="short" prefix=", "/>
     </names>
   </macro>


### PR DESCRIPTION
## 現象

本文言語が日本語 (`text(lang: "ja")`) の文書で参考文献を組むと、欧文文献の著者接続が「P. Van Overschee **と** B. De Moor」のように日本語の「と」になる。全 7 つの CSL ファイルで再現する。

## 原因

CSL 公式 ja-JP ロケールが `<term name="and">と</term>` を定義しており、`and="text"` 指定の name 要素が文書言語 ja でこの訳語を引くため。style 要素の `default-locale` では直らない (`en-US` 指定の rsj.csl でも再現。hayagriva は文書言語のロケールで語彙を解決する)。sice.csl 既存の `<locale xml:lang="en">` ブロック (「なぜかenしか効かない」コメントの箇所) も同じ理由で ja 文書では効いていなかった。

## 修正

- 全 CSL に **xml:lang 無しの style 内ロケール定義**で `<term name="and">and</term>` を追加 (style 内定義はロケールファイルより優先されるため、文書言語によらず " and " 接続になる)
- sice 系 3 ファイルは同ブロックへ `page-range-delimiter` も移動し、ja 文書でもページ範囲が「102/107」形式になるよう修正 (これまで「102–107」になっていた)
- sice 系 + rengo + sci の欧文 name 要素に `delimiter-precedes-last="never"` を追加し、「A, B and C」(and の前にカンマ無し) に統一

## 書式の根拠

- SICE 論文執筆の手引き §3.5: 和文は苗字のみ「，」連記 (現状の挙動どおり・変更なし)、欧文実例は計測自動制御学会論文集 53-6 掲載論文の「L. Sun, H. Ohmori and A. Sano」等 (serial comma 無し)
- 第67回自動制御連合講演会 LaTeX テンプレの文献例「T. Jido and J. Jido: Paper title; …」
- rsj 系 2 ファイルは RSJ の serial comma 慣行を一次資料で確認できなかったため、「と」→「and」の語彙上書きのみ (連記区切りは従来挙動を維持)

## 確認

欧文 2/3 名 + 和文 4 名連名の文献リストを `lang: "ja"` でレンダリングし、全スタイルで before/after を目視確認:

- sice 系: 「K. Yamada, I. Maruta and K. Fujimoto」・ページ範囲「102/107」・和文「木村，丸田，…」(不変)
- rengo / sci: 「M. Sugimoto and A. Sramoon:」
- rsj 系: 「と」のみ解消 (「I. Maruta, and K. Fujimoto」の contextual serial comma は従来どおり)

`tests/test-compile-doc.typ` のコンパイル通過も確認済み。