### PR TITLE
Fix: 和文文書で参考文献の vol./no./pp. が「巻/号/ページ」になる問題を修正

### DIFF
--- a/examples/rengo/rengo.csl
+++ b/examples/rengo/rengo.csl
@@ -20,6 +20,18 @@
   <locale>
     <terms>
       <term name="and">and</term>
+      <term name="volume" form="short">
+        <single>vol.</single>
+        <multiple>vols.</multiple>
+      </term>
+      <term name="issue" form="short">
+        <single>no.</single>
+        <multiple>nos.</multiple>
+      </term>
+      <term name="page" form="short">
+        <single>p.</single>
+        <multiple>pp.</multiple>
+      </term>
     </terms>
   </locale>
   <locale xml:lang="en">

--- a/examples/rsj-conf/rsj-conf.csl
+++ b/examples/rsj-conf/rsj-conf.csl
@@ -20,6 +20,20 @@
   <locale>
     <terms>
       <term name="and">and</term>
+      <term name="volume" form="short">
+        <single>vol.</single>
+        <multiple>vols.</multiple>
+      </term>
+      <term name="issue" form="short">
+        <single>no.</single>
+        <multiple>nos.</multiple>
+      </term>
+      <term name="page" form="short">
+        <single>p.</single>
+        <multiple>pp.</multiple>
+      </term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
     </terms>
   </locale>
   <macro name="edition">

--- a/examples/sci/sci.csl
+++ b/examples/sci/sci.csl
@@ -20,6 +20,18 @@
   <locale>
     <terms>
       <term name="and">and</term>
+      <term name="volume" form="short">
+        <single>vol.</single>
+        <multiple>vols.</multiple>
+      </term>
+      <term name="issue" form="short">
+        <single>no.</single>
+        <multiple>nos.</multiple>
+      </term>
+      <term name="page" form="short">
+        <single>p.</single>
+        <multiple>pp.</multiple>
+      </term>
     </terms>
   </locale>
   <locale xml:lang="en">

--- a/src/rsj.csl
+++ b/src/rsj.csl
@@ -20,6 +20,20 @@
   <locale>
     <terms>
       <term name="and">and</term>
+      <term name="volume" form="short">
+        <single>vol.</single>
+        <multiple>vols.</multiple>
+      </term>
+      <term name="issue" form="short">
+        <single>no.</single>
+        <multiple>nos.</multiple>
+      </term>
+      <term name="page" form="short">
+        <single>p.</single>
+        <multiple>pp.</multiple>
+      </term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
     </terms>
   </locale>
   <macro name="edition">


### PR DESCRIPTION
## 現象

#54 の「と」と同根の残件。本文言語が日本語 (`text(lang: "ja")`) の文書で参考文献を組むと、CSL ja-JP ロケールの語彙が引かれて以下のようになる。

- rsj 系 (`src/rsj.csl`・`examples/rsj-conf/rsj-conf.csl`): 「巻 32, 号 1, ページ 102–107」(en 文書では vol. 32, no. 1, pp.102–107)。論文題目の引用符も「…」(en では “…”)
- rengo / sci: 「ページ 102–107」(en では pp.102–107)

## 修正

#54 で導入した xml:lang 無しの style 内ロケール定義に、各スタイルが参照する term を追加。

- rsj 系 + rengo + sci: `volume` (vol./vols.)・`issue` (no./nos.)・`page` (p./pp.)
- rsj 系のみ: `open-quote` / `close-quote` (“ ”)

体裁の正は、これまでテスト文書 (`#set text(lang: "en")` で組まれている) が出力してきた en 体裁とした。これにより文書言語 ja / en で参考文献の出力が一致する (#54 後の sice 系と同じ状態)。

### 意図的に対象外としたもの

- **punctuation-in-quote**: rsj の ja 文書は `“…”,` (句読点が引用符の外)、en 文書は en-US ロケール既定で `“…,”` のまま。RSJ の和文文献例は句読点を引用符の外に置くため、ja 側を正として上書きしない
- **`edition` term・editor label**: ja で「版」「編」になり得るが、参照している文献実例が無く ordinal との組合せも検証できないため見送り

## 確認

欧文 2/3/4 名 + 和文連名の文献リストを before (main) / after (本ブランチ) × `lang: "ja"` / `"en"` の全組合せでレンダリングし pdftotext で比較:

- **en 出力は 3 スタイルとも完全一致** (本 PR で en 文書の出力は変わらない)
- rengo / sci は ja == en が完全一致
- rsj は ja で「vol. 32, no. 1, pp.102–107」「“Subspace identification for linear systems”」となり、句読点位置を除き en と一致
- 和文文献は従来どおり苗字連記のまま (rsj の和文誌は en 体裁どおり vol./no./pp. 表記)

全 4 ファイル xmllint で well-formed、`src/rsj.csl` ≡ `examples/rsj-conf/rsj-conf.csl` の同期維持、`tests/test-compile-doc.typ` のコンパイル通過も確認済み。
