### PR TITLE
Fix: テストの参考文献が実利用と異なる言語設定で組まれる問題を修正

### DIFF
--- a/tests/test-compile-doc.typ
+++ b/tests/test-compile-doc.typ
@@ -429,10 +429,7 @@ CSLファイルは著者が編集する必要はありませんが、詳細が�
 
 最後までお読みいただき誠にありがとうございました。
 
-#block[
-  #set text(lang: "en")
-  #bibliography("refs.yml", full: false)
-]
+#bibliography("refs.yml", full: false)
 
 #show: appendix.with(numbering-appendix: "A.1")
 


### PR DESCRIPTION
## 背景

#54 の「と」バグ (欧文著者接続が日本語の「と」になる) は長期間テスト文書で検出できなかった。原因は `tests/test-compile-doc.typ` だけが bibliography を

```typst
#block[
  #set text(lang: "en")
  #bibliography("refs.yml", full: false)
]
```

と `lang: "en"` のブロックで囲んでいたため。`template/main.typ` (実際にユーザーが使う雛形) は素の `#bibliography("refs.yml", full: false)` であり、文書言語 ja のまま参考文献が組まれる。つまりテスト文書だけが問題を回避する書き方になっており、ja ロケール語彙の混入 (「と」「巻/号/ページ」等) はテスト側では再現しなかった。

## 修正

ブロックと `#set text(lang: "en")` を外し、`template/main.typ` と同じ素の `#bibliography("refs.yml", full: false)` にする。

なお `src/lib.typ` の `show bibliography` 内にある `set text(lang: "en")` は表示 (フォント・ハイフネーション等) にのみ効き、hayagriva の term 解決には影響しない (#54 以前の実文書で「と」が出ていたことから確認済み)。ここは変更しない。

## 確認

- **出力不変**: #54 適用後の main では sice.csl の ja/en 出力が一致するため、本変更でテスト PDF の参考文献 7 件の内容は before/after で完全一致 (pdftotext で比較)。`#block` 除去による二段組内の配置がわずかに変わるのみ
- **遡及検証**: #54 以前のツリー (39dad46) に本修正を当ててコンパイルすると、テスト PDF に「S. Kimura, H. Nakamura, と Y. Yamashita」が出力される。この経路なら「と」の退行はテスト文書 (リリース添付 PDF) 上で見えていた
- コンパイル通過確認済み (CI 相当)
