### PR TITLE
Fix: example のビルドにローカル CSL 修正が反映されない問題を修正

### DIFF
--- a/examples/mscs/lib.typ
+++ b/examples/mscs/lib.typ
@@ -28,6 +28,8 @@
     font-heading: font-gothic,
     font-main: font-mincho,
     font-latin: font-latin,
+    // 外観 Appearance
+    bibliography-style: bytes(read("sice.csl")),
     // 見出し Headings
     heading-abstract: [*Abstract--* #h(0.5em)],
     heading-keywords: [*Key Words*: #h(1em)],

--- a/examples/rsj-conf/lib.typ
+++ b/examples/rsj-conf/lib.typ
@@ -31,7 +31,7 @@
     font-latin: font-latin,
     // 外観 Appearance
     spacing-heading: 10pt,
-    bibliography-style: "rsj.csl",  // "sice.csl", "rsj.csl", "ieee", etc.
+    bibliography-style: bytes(read("rsj-conf.csl")),
     abstract-language: abstract-language,
     // 見出し Headings
     heading-abstract: [#h(1em)],


### PR DESCRIPTION
## 現象

#54・#55 で CSL を修正したのに、`examples/example.typ` をコンパイルしても mscs (既定)・rsj-conf では反映されない (「と」のまま)。

## 原因

mscs / rsj-conf の lib.typ は CSL を公開 package 内で解決しており、repo 内の CSL コピーがビルドで読まれていなかった。

- `examples/mscs/lib.typ`: `bibliography-style` 未指定 → package 既定の `"sice.csl"` が `@preview/jaconf:0.7.1` (パッケージキャッシュ) 内で解決される
- `examples/rsj-conf/lib.typ`: 文字列 `"rsj.csl"` は Typst の仕様で文字列リテラルのある側ではなく package 内パスとして解決される

つまり `examples/mscs/sice.csl`・`examples/rsj-conf/rsj-conf.csl` は**ビルドに使われない死にコピー**で、#54/#55 の同期更新も出力に影響していなかった。rengo / sci / sice-si は既に `bytes(read("○○.csl"))` でローカル読みのため問題なし。

## 修正

mscs / rsj-conf も他 3 例と同じ `bytes(read())` 方式に統一。

- `examples/mscs/lib.typ`: `bibliography-style: bytes(read("sice.csl"))` を追加
- `examples/rsj-conf/lib.typ`: `"rsj.csl"` → `bytes(read("rsj-conf.csl"))`

これで examples 配下の CSL コピーが実際にビルドで読まれ、repo の修正が即座に example の出力へ反映される。

## 確認

example.typ の import を 5 テンプレートすべてに切り替えてコンパイルし、pdftotext で検証:

- **mscs**: 「S. Kimura, H. Nakamura and Y. Yamashita」・ページ範囲「122/130」(#54/#55 反映) ✅
- **rsj-conf**: 「vol. 5, no. 2, pp.122–130」・題目 “…” (#55 反映、contextual serial comma は従来どおり) ✅
- **rengo / sci / sice-si**: 従来どおり (非破壊) ✅

`tests/test-compile-doc.typ` のコンパイル通過も確認済み。

## 補足

`template/main.typ` は `@preview/jaconf:0.7.1` 固定のため、エンドユーザーに #54/#55 が届くには 0.7.2 のリリースが別途必要 (本 PR の範囲外)。
