### PR TITLE
Update: 和文学術論文誌のサンプル文献を共著のものに差し替え

### DIFF
--- a/examples/example.typ
+++ b/examples/example.typ
@@ -370,7 +370,7 @@ CSLファイルは著者が編集する必要はありませんが、詳細が�
 
 == 引用
 引用は "\@label" と記述することで、数式であれば@eq:system、図であれば@fig:quadratic、表であれば@tab:fonts、セクションであれば@sec:edit、節や項があるセクションであれば@sec:typst-install、付録セクションであれば@appendix:edit、参考文献であれば@kimura2015asymptotic のように表示されます。
-参考文献は連続して引用すると @kimura2023doctor @kimura2021control @kimura2020facility @khalil2002control @sugie1999feedback @caamp2025aisuitcase と表示されます。
+参考文献は連続して引用すると @kimura2025collision @kimura2021control @kimura2020facility @khalil2002control @sugie1999feedback @caamp2025aisuitcase と表示されます。
 文法上では特に規則はありませんが、個人的にはラベルの命名規則として、数式の場合には "eq:" から、図の場合には "fig:" から、表の場合には"tab:" から、セクションの場合には "sec:" から、付録セクションであれば "appendix:" から始めるようにラベル名を設定しており、参考文献のラベルは "著者名発行年タイトルの最初の単語"で名付けております。
 
 = おわりに <sec:conclusion>

--- a/examples/refs.yml
+++ b/examples/refs.yml
@@ -13,18 +13,18 @@ kimura2015asymptotic:
         publisher: Taylor & Francis
 
 # 和文学術論文誌
-kimura2023doctor:
+kimura2025collision:
     language: japanese
     type: Article
-    title: 制御理論専攻の学生生活と建設会社への入社
-    author: ["木村, 駿介"]
-    page-range: 342-345
-    date: 2023
+    title: 2次元LiDAR制御バリア関数による衝突回避ヒューマンアシスト制御
+    author: ["木村, 駿介", "西本, 昂樹"]
+    page-range: 194-202
+    date: 2025
     parent:
         type: Periodical
-        title: 計測と制御
-        volume: 62
-        issue: 6
+        title: 計測自動制御学会論文集
+        volume: 61
+        issue: 3
         publisher: 公益社団法人 計測自動制御学会
 
 # 国際会議論文

--- a/template/main.typ
+++ b/template/main.typ
@@ -167,7 +167,7 @@ $ u = K_P e + K_I integral_0^t e d t $ <eq:PI-controller>
 
 === 引用
 引用は "\@label" と記述することで、数式であれば@eq:system、図であれば@fig:quadratic、表であれば@tab:fonts、セクションであれば@sec:intro、節や項があるセクションであれば@sec:theorem、付録セクションであれば@appendix:edit、参考文献であれば@kimura2015asymptotic のように表示されます。
-参考文献は連続して引用すると @kimura2023doctor @kimura2021control @kimura2020facility @khalil2002control @sugie1999feedback @caamp2025aisuitcase と表示されます。
+参考文献は連続して引用すると @kimura2025collision @kimura2021control @kimura2020facility @khalil2002control @sugie1999feedback @caamp2025aisuitcase と表示されます。
 文法上では特に規則はありませんが、個人的にはラベルの命名規則として、数式の場合には "eq:" から、図の場合には "fig:" から、表の場合には"tab:" から、セクションの場合には "sec:" から、付録セクションであれば "appendix:" から始めるようにラベル名を設定しており、参考文献のラベルは "著者名発行年タイトルの最初の単語"で名付けております。
 
 = おわりに <sec:conclusion>

--- a/template/refs.yml
+++ b/template/refs.yml
@@ -13,18 +13,18 @@ kimura2015asymptotic:
         publisher: Taylor & Francis
 
 # 和文学術論文誌
-kimura2023doctor:
+kimura2025collision:
     language: japanese
     type: Article
-    title: 制御理論専攻の学生生活と建設会社への入社
-    author: ["木村, 駿介"]
-    page-range: 342-345
-    date: 2023
+    title: 2次元LiDAR制御バリア関数による衝突回避ヒューマンアシスト制御
+    author: ["木村, 駿介", "西本, 昂樹"]
+    page-range: 194-202
+    date: 2025
     parent:
         type: Periodical
-        title: 計測と制御
-        volume: 62
-        issue: 6
+        title: 計測自動制御学会論文集
+        volume: 61
+        issue: 3
         publisher: 公益社団法人 計測自動制御学会
 
 # 国際会議論文

--- a/tests/refs.yml
+++ b/tests/refs.yml
@@ -13,18 +13,18 @@ kimura2015asymptotic:
         publisher: Taylor & Francis
 
 # 和文学術論文誌
-kimura2023doctor:
+kimura2025collision:
     language: japanese
     type: Article
-    title: 制御理論専攻の学生生活と建設会社への入社
-    author: ["木村, 駿介"]
-    page-range: 342-345
-    date: 2023
+    title: 2次元LiDAR制御バリア関数による衝突回避ヒューマンアシスト制御
+    author: ["木村, 駿介", "西本, 昂樹"]
+    page-range: 194-202
+    date: 2025
     parent:
         type: Periodical
-        title: 計測と制御
-        volume: 62
-        issue: 6
+        title: 計測自動制御学会論文集
+        volume: 61
+        issue: 3
         publisher: 公益社団法人 計測自動制御学会
 
 # 国際会議論文

--- a/tests/test-compile-doc.typ
+++ b/tests/test-compile-doc.typ
@@ -406,7 +406,7 @@ CSLファイルは著者が編集する必要はありませんが、詳細が�
 
 == 引用
 引用は "\@label" と記述することで、数式であれば@eq:system、図であれば@fig:quadratic、表であれば@tab:fonts、セクションであれば@sec:edit、節や項があるセクションであれば@sec:typst-install、付録セクションであれば@appendix:edit、参考文献であれば@kimura2015asymptotic のように表示されます。
-参考文献は連続して引用すると @kimura2023doctor @kimura2021control @kimura2020facility @khalil2002control @sugie1999feedback @caamp2025aisuitcase と表示されます。
+参考文献は連続して引用すると @kimura2025collision @kimura2021control @kimura2020facility @khalil2002control @sugie1999feedback @caamp2025aisuitcase と表示されます。
 文法上では特に規則はありませんが、個人的にはラベルの命名規則として、数式の場合には "eq:" から、図の場合には "fig:" から、表の場合には"tab:" から、セクションの場合には "sec:" から、付録セクションであれば "appendix:" から始めるようにラベル名を設定しており、参考文献のラベルは "著者名発行年タイトルの最初の単語"で名付けております。
 
 = おわりに <sec:conclusion>


### PR DESCRIPTION
## 背景

`refs.yml` の和文学術論文誌サンプル `kimura2023doctor` は**単著**だったため、和文文献の連名表記 (SICE 手引き §3.5「連名の場合は論文・単行本ともに苗字だけとする」) がサンプル出力で例示できていなかった。#54 以降の一連の CSL 修正でも、和文側の連記挙動は目視確認しづらい状態だった。

なお `refs.bib` 側の和文学術論文誌は元から 4 名共著 (`kimura2017state`) で、yml と bib でサンプルが揃っていなかった。

## 変更

和文学術論文誌のサンプルを 2 名共著の実在論文に差し替える。

- `kimura2023doctor` (単著・計測と制御 62-6) → `kimura2025collision` (木村・西本の 2 名・計測自動制御学会論文集 61-3, 194-202, 2025)
- ラベルは既存の命名規則 (著者名 + 発行年 + 英文タイトルの最初の単語) に従い `kimura2025collision`
- `tests/` `examples/` `template/` の refs.yml 3 ファイルと、`@kimura2023doctor` を参照する .typ 3 ファイルを追随

書誌は CrossRef (DOI [10.9746/sicetr.61.194](https://doi.org/10.9746/sicetr.61.194)) で確認済み。

## 確認

`tests/test-compile-doc.typ` を sice / rsj 両スタイルでコンパイルし、pdftotext で出力を確認:

- **sice**: `2) 木村, 西本, 2次元LiDAR制御バリア関数による衝突回避ヒューマンアシスト制御, 計測自動制御学会論文集, 61-3, 194/202 (2025).`
  → 苗字のみの連記・ページ範囲 `194/202` ともに SICE 手引き §3.5 の書式どおり
- **rsj**: `[2] 木村, 西本, “…”, 計測自動制御学会論文集, vol. 61, no. 3, pp.194–202, 2025.`

`kimura2023doctor` の残存が repo 全体で 0 件であることも確認済み (コンパイル通過確認済み)。

## 補足

`refs.bib` の和文学術論文誌 (`kimura2017state`) は既に共著サンプルのため本 PR では変更していない。yml と bib で同一論文に揃えるかは別途判断。
